### PR TITLE
Specify dash for isAtext at the beginning

### DIFF
--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -74,7 +74,7 @@ isSpecial :: Word8 -> Bool
 isSpecial = inClass "()<>[]:;@\\,.\""
 
 isAtext :: Word8 -> Bool
-isAtext = inClass "A-Za-z0-9!#$%&'*+-/=?^_`{|}~"
+isAtext = inClass "-A-Za-z0-9!#$%&'*+/=?^_`{|}~"
 
 isWsp :: Word8 -> Bool
 isWsp = inClass "\t "


### PR DESCRIPTION
isAtext was mistakenly specifying a range from ASCII characters '+' to '/' which
included ASCII characters like ',', '-' and '.'. This resulted in wrong parser
results, even tho not very obvious.

This patch puts the dash to the beginning in accordance to the documentation.