### PR TITLE
fix MIME epilogue parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ install:
 script:
   # test that source-distributions can be generated
   - (cd "." && cabal sdist)
-  - mv "."/dist/purebred-email-*.tar.gz ${DISTDIR}/
+  - mv ./dist/purebred-email-*.tar.gz ${DISTDIR}/ || mv ./dist-newstyle/sdist/purebred-email-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
   - "printf 'packages: purebred-email-*/*.cabal\\n' > cabal.project"

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -613,7 +613,7 @@ multipart takeTillEnd boundary =
     multipartBody =
       skipTillString dashBoundary *> crlf -- FIXME transport-padding
       *> part `sepBy` crlf
-      <* string "--" <* crlf <* void takeTillEnd
+      <* string "--" <* takeTillEnd
 
 -- | Serialise a given `MIMEMessage` into a ByteString. The message is
 -- serialised as is. No additional headers are set.

--- a/test-vectors/nested-multipart.eml
+++ b/test-vectors/nested-multipart.eml
@@ -1,0 +1,16 @@
+Content-Type: multipart/mixed; boundary=boundary1
+MIME-Version: 1.0
+Date: Thu, 4 May 2017 03:08:43 +1000 (EST)
+From: foo@bar
+To: my@email.test
+Subject: Pretty subject
+
+--boundary1
+Content-Type: multipart/alternative; boundary=boundary2
+
+--boundary2
+Content-Type: text/plain
+
+Bla bla bla
+--boundary2--
+--boundary1--


### PR DESCRIPTION
RFC 2046 defines:

     multipart-body := [preamble CRLF]
                       dash-boundary transport-padding CRLF
                       body-part *encapsulation
                       close-delimiter transport-padding
                       [CRLF epilogue]

Our current MIME parser is defined as (equivalent to):

    ...
    closeDelimeter <* crlf <* takeTillEnd

where 'takeTillEnd' provides everything up to the "end" of the
message, which for a "top-level" multipart message is the end of the
entire input, and for a nested multipart message is everything up
to, but not including, the boundary of the enclosing multipart
message, __preceded by a LF__.

Therefore a mail containing nested multipart messages where the
close-delimeters are separated by only a single newline does not
parse.  For example, the following message will not parse:

```
Content-Type: multipart/mixed; boundary=boundary1
MIME-Version: 1.0
Date: Thu, 4 May 2017 03:08:43 +1000 (EST)
From: foo@bar
To: my@email.test
Subject: Pretty subject

--boundary1
Content-Type: multipart/alternative; boundary=boundary2

--boundary2
Content-Type: text/plain

Bla bla bla
--boundary2--
--boundary1--
```

Because we already discard the epilogue, the solution is simply to
omit the CRLF parse after the close-delimiter, i.e.:

    ...
    closeDelimeter <* takeTillEnd

Fixes: https://github.com/purebred-mua/purebred-email/issues/23