### PR TITLE
ci: add ghc-8.8.1 to matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ before_cache:
 
 matrix:
   include:
-    - compiler: "ghc-8.6.3"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.3], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.8.1"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.6.5"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.4], sources: [hvr-ghc]}}
@@ -45,6 +47,7 @@ matrix:
 
   allow_failures:
     - compiler: "ghc-head"
+    - compiler: "ghc-8.8.1"
 
 before_install:
   - HC=${CC}

--- a/purebred-email.cabal
+++ b/purebred-email.cabal
@@ -35,7 +35,7 @@ extra-source-files:
   tests/golden/*.golden
 cabal-version:       >=1.10
 tested-with:
-  GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.3
+  GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.1
 
 homepage:            https://github.com/purebred-mua/purebred-email
 bug-reports:         https://github.com/purebred-mua/purebred-email/issues


### PR DESCRIPTION
Also bump ghc-8.6.3 -> ghc-8.6.5, and explicitly use
cabal-install-2.4 and cabal-install-3.0 for 8.6.x and 8.8.x
respectively.