### PR TITLE
Expose functions to render addresses to text

### DIFF
--- a/src/Data/RFC5322/Address/Text.hs
+++ b/src/Data/RFC5322/Address/Text.hs
@@ -11,6 +11,8 @@ module Data.RFC5322.Address.Text
   -- * Pretty printing
   , renderMailbox
   , renderMailboxes
+  , renderAddress
+  , renderAddresses
   ) where
 
 import Control.Applicative ((<|>), optional)
@@ -45,6 +47,13 @@ buildMailbox (Mailbox n a) =
   maybe a' (\n' -> "\"" <> Builder.fromText n' <> "\" " <> "<" <> a' <> ">") n
   where
     a' = renderAddressSpec a
+
+renderAddresses :: [Address] -> T.Text
+renderAddresses xs = T.intercalate ", " $ renderAddress <$> xs
+
+renderAddress :: Address -> T.Text
+renderAddress (Single m) = renderMailbox m
+renderAddress (Group name xs) = name <> ":" <> renderMailboxes xs <> ";"
 
 renderAddressSpec :: AddrSpec -> Builder.Builder
 renderAddressSpec (AddrSpec lp (DomainDotAtom b))


### PR DESCRIPTION
This is a needed for round tripping mails in purebred: when editing
mails as new, we want to populate the editor fields with header
values. Using a combination of header* lenses with rendering the given
addresses populates the fields without re-implementing those functions
on the purebred side.