### PR TITLE
support user-supplied charsets

### DIFF
--- a/purebred-email.cabal
+++ b/purebred-email.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                purebred-email
-version:             0.1.0.1
+version:             0.2.0.0
 synopsis:            types and parser for email messages (including MIME)
 description:
   The purebred email library.  RFC 5322, MIME, etc.
@@ -26,7 +26,7 @@ license:             AGPL-3
 license-file:        LICENSE
 author:              Fraser Tweedale
 maintainer:          frase@frase.id.au
-copyright:           Copyright 2017-2018  Fraser Tweedale
+copyright:           Copyright 2017-2019  Fraser Tweedale
 category:            Data, Email
 build-type:          Simple
 extra-source-files:

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -85,6 +85,8 @@ module Data.MIME
   , createMultipartMixedMessage
 
   -- * Re-exports
+  , CharsetLookup
+  , defaultCharsets
   , module Data.RFC5322
   , module Data.MIME.Parameter
   , module Data.MIME.Error
@@ -380,7 +382,7 @@ instance HasCharset ByteEntity where
       else
         preview l params <|> Just "us-ascii"
   charsetData = body -- XXX: do we need to drop the BOM / encoding decl?
-  charsetDecoded = to $ \a -> (\t -> set body t a) <$> view charsetText a
+  charsetDecoded m = to $ \a -> (\t -> set body t a) <$> view (charsetText m) a
 
   -- | Encode (@utf-8@) and add/set charset parameter.  If consisting
   -- entirely of ASCII characters, the @charset@ parameter gets set to
@@ -536,8 +538,8 @@ contentDisposition =
 
 -- | Traverse the value of the filename parameter (if present).
 --
-filename :: HasParameters a => Traversal' a T.Text
-filename = filenameParameter . traversed . charsetPrism . value
+filename :: HasParameters a => CharsetLookup -> Traversal' a T.Text
+filename m = filenameParameter . traversed . charsetPrism m . value
 
 -- | Access the filename parameter as a @Maybe ('ParameterValue' B.ByteString)@.
 --

--- a/src/Data/MIME/EncodedWord.hs
+++ b/src/Data/MIME/EncodedWord.hs
@@ -101,7 +101,7 @@ transferEncodeEncodedWord (TransferDecodedEncodedWord charset lang s) =
 -- encoded-words and decodes them.
 --
 -- @
--- λ> T.putStrLn $ decodeEncodedWords "hello =?utf-8?B?5LiW55WM?=!"
+-- λ> T.putStrLn $ decodeEncodedWords defaultCharsets "hello =?utf-8?B?5LiW55WM?=!"
 -- hello 世界!
 -- @
 --
@@ -109,22 +109,22 @@ transferEncodeEncodedWord (TransferDecodedEncodedWord charset lang s) =
 -- is left unchanged in the result.
 --
 -- @
--- λ> T.putStrLn $ decodeEncodedWords "=?utf-8?B?bogus?="
+-- λ> T.putStrLn $ decodeEncodedWords defaultCharsets "=?utf-8?B?bogus?="
 -- =?utf-8?B?bogus?=
 --
--- λ> T.putStrLn $ decodeEncodedWords "=?utf-8?X?unrecognised_encoding?="
+-- λ> T.putStrLn $ decodeEncodedWords defaultCharsets "=?utf-8?X?unrecognised_encoding?="
 -- =?utf-8?X?unrecognised_encoding?=
 -- @
 --
 -- Language specification is supported (the datum is discarded).
 --
 -- @
--- λ> T.putStrLn $ decodeEncodedWords "=?utf-8*es?Q?hola_mundo!?="
+-- λ> T.putStrLn $ decodeEncodedWords defaultCharsets "=?utf-8*es?Q?hola_mundo!?="
 -- hola mundo!
 -- @
 --
-decodeEncodedWords :: B.ByteString -> T.Text
-decodeEncodedWords s =
+decodeEncodedWords :: CharsetLookup -> B.ByteString -> T.Text
+decodeEncodedWords charsets s =
   either (const $ decodeLenient s) merge $ fmap (g . f) <$> parseOnly tokens s
   where
     -- parse the ByteString into a series of tokens
@@ -140,6 +140,6 @@ decodeEncodedWords s =
     g (Left t) = Left t
     g (Right w) = first
       (const $ serialiseEncodedWord $ transferEncodeEncodedWord w :: CharsetError -> B.ByteString)
-      (view charsetDecoded w)
+      (view (charsetDecoded charsets) w)
 
     merge = foldMap (either decodeLenient id)

--- a/src/Data/MIME/Parameter.hs
+++ b/src/Data/MIME/Parameter.hs
@@ -183,7 +183,7 @@ charset f (ParameterValue a b c) = (\a' -> ParameterValue a' b c) <$> f a
 -- constructor directly.
 --
 newParameter :: T.Text -> EncodedParameterValue
-newParameter = review charsetPrism . ParameterValue Nothing Nothing
+newParameter = charsetEncode . ParameterValue Nothing Nothing
 
 
 -- | The default charset @us-ascii@ is implied by the abstract of
@@ -198,7 +198,7 @@ instance HasCharset EncodedParameterValue where
   type Decoded EncodedParameterValue = DecodedParameterValue
   charsetName = to $ \(ParameterValue name _ _) -> name <|> Just "us-ascii"
   charsetData = value
-  charsetDecoded = to $ \a -> (\t -> (set charset Nothing . set value t) a) <$> view charsetText a
+  charsetDecoded m = to $ \a -> (\t -> (set charset Nothing . set value t) a) <$> view (charsetText m) a
   charsetEncode (ParameterValue _ lang s) =
     let
       bs = T.encodeUtf8 s

--- a/tests/MIME.hs
+++ b/tests/MIME.hs
@@ -139,7 +139,7 @@ testContentDisposition =
         )
     ]
   where
-    lFilename = headers . contentDisposition . filename
+    lFilename = headers . contentDisposition . filename defaultCharsets
     stripPath = snd . T.breakOnEnd "/"
 
 testParse :: TestTree


### PR DESCRIPTION
In order to support arbitrary charsets without additional
dependencies, add support for user-specific charset lookups.  This
is an API-breaking change, so bump the major version too.

Fixes: https://github.com/purebred-mua/purebred-email/issues/5

@romanofski I've had this change sitting around for a while, along with
a patch for the corresponding updates in purebred, and the prototype
ICU plugin that adds support for charsets via *libicu*.  Since we were looking
at cutting a new purebred-email release I figure now is a good time to land this
change as well.  If we decide to land this now, the plan for purebred is:

1. a minimal change in purebred to use purebred-email-0.2 (with no behavioural change)
2. the change to add support for charset plugins
3. publish the ICU plugin as a separate library

If you want to see POC for any of the above *before landing this change* in
purebred-email, fair enough, I can arrange that; just let me know.