### PR TITLE
Export parsers for parsing address and mailbox lists

### DIFF
--- a/src/Data/RFC5322/Address/Text.hs
+++ b/src/Data/RFC5322/Address/Text.hs
@@ -7,7 +7,9 @@ Parser for roundtripping Text based `Mailbox`es and addresses.
 module Data.RFC5322.Address.Text
   (
     mailbox
+  , mailboxList
   , address
+  , addressList
   -- * Pretty printing
   , renderMailbox
   , renderMailboxes
@@ -76,6 +78,9 @@ displayName = phrase
 
 mailboxList :: Parser [Mailbox]
 mailboxList = mailbox `sepBy` char ','
+
+addressList :: Parser [Address]
+addressList = address `sepBy` char ','
 
 group :: Parser Address
 group = Group <$> displayName <* char ':' <*> mailboxList <* char ';' <* optionalCFWS


### PR DESCRIPTION
These parsers will be valuable add-ons to use when roundtripping mails
in purebred.