### PR TITLE
Revert change for generator

### DIFF
--- a/tests/Headers.hs
+++ b/tests/Headers.hs
@@ -310,7 +310,7 @@ multipleMailboxes =
 
 -- | Generate headers
 genFieldItem :: Gen B.ByteString
-genFieldItem = resize 55 . B.pack <$> listOf1 (suchThat arbitrary isFtext)
+genFieldItem = resize 55 (B.pack <$> listOf1 (suchThat arbitrary isFtext))
 
 isFtext :: Word8 -> Bool
 isFtext c = (c >= 33 && c <= 57) || (c >= 59 && c <= 126)


### PR DESCRIPTION
This was mistakenly changed to appease hlint in
28428a91eef9a5a0a0b608c61ea820dc96d5b024 but actually broke the test.