### PR TITLE
fix headerFrom/To/CC/BCC, add doc; fix dot-atom parsing

### DIFF
--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -147,13 +147,34 @@ Create an inline, plain text message and render it:
 λ> B.putStrLn s
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
-Content-Type: text/plain; charset=us-ascii
 Content-Disposition: inline
+Content-Type: text/plain; charset=us-ascii
 
 Hello, world!
 @
 
-__TODO__ show how to set From,To,Cc,etc.
+Set the @From@ and @To@ headers:
+
+@
+λ> alice = Mailbox Nothing (AddrSpec "alice" (DomainDotAtom ("example" :| ["com"])))
+λ> bob = Mailbox Nothing (AddrSpec "bob" (DomainDotAtom ("example" :| ["net"])))
+λ> msgFromAliceToBob = set 'headerFrom' [alice] . set 'headerTo' [Single bob] $ msg
+λ> B.putStrLn (renderMessage msgFromAliceToBob)
+MIME-Version: 1.0
+From: alice@example.com
+To: bob@example.net
+Content-Transfer-Encoding: 7bit
+Content-Disposition: inline
+Content-Type: text/plain; charset=us-ascii
+
+Hello, world!
+@
+
+The 'headerFrom', 'headerTo', 'headerCC' and 'headerBCC' lenses are the most
+convenient interface for reading and setting the sender and recipient
+addresses.  Note that you would usually not manually construct email addresses
+manually as was done above.  Instead you would usually read it from another
+email or configuration, or parse addresses from user input.
 
 Create a multipart message with attachment:
 

--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -275,7 +275,7 @@ isDtext :: Word8 -> Bool
 isDtext c = (c >= 33 && c <= 90) || (c >= 94 && c <= 126)
 
 domain :: Parser Domain
-domain = (DomainDotAtom <$> (pure <$> dotAtom))
+domain = (DomainDotAtom <$> dotAtom)
          <|> (DomainLiteral <$> domainLiteral)
 
 mailboxList :: Parser [Mailbox]

--- a/src/Data/RFC5322/Address/Text.hs
+++ b/src/Data/RFC5322/Address/Text.hs
@@ -97,5 +97,5 @@ addressSpec :: Parser AddrSpec
 addressSpec = AddrSpec <$> (T.encodeUtf8 <$> localPart) <*> (char '@' *> domain)
 
 domain :: Parser Domain
-domain = (DomainDotAtom <$> (pure . T.encodeUtf8 <$> dotAtom))
-         <|> (DomainLiteral <$> (T.encodeUtf8 <$> domainLiteral))
+domain = (DomainDotAtom . fmap T.encodeUtf8 <$> dotAtom)
+         <|> (DomainLiteral . T.encodeUtf8 <$> domainLiteral)

--- a/tests/Headers.hs
+++ b/tests/Headers.hs
@@ -108,7 +108,7 @@ rendersAddressesToTextSuccessfully =
 mailboxFixtures :: IsString s => [(String, Either String Mailbox -> Assertion, s)]
 mailboxFixtures =
     [ ( "address with FQDN"
-      , (Right (Mailbox Nothing (AddrSpec "foo" (DomainDotAtom $ pure "bar.com"))) @=?)
+      , (Right (Mailbox Nothing (AddrSpec "foo" (DomainDotAtom $ "bar" :| ["com"]))) @=?)
       , "foo@bar.com")
     , ( "just with a host name"
       , (Right (Mailbox Nothing (AddrSpec "foo" (DomainDotAtom $ pure "bar"))) @=?)
@@ -144,7 +144,7 @@ mailboxFixtures =
       , assertBool "Parse error expected" . isLeft
       , "foo@,bar,com")
     , ( "displayName without quotes but with spaces"
-      , (Right (Mailbox (Just "John Doe") (AddrSpec "jdoe" (DomainDotAtom $ pure "machine.example"))) @=?)
+      , (Right (Mailbox (Just "John Doe") (AddrSpec "jdoe" (DomainDotAtom $ "machine" :| ["example"]))) @=?)
       , "John Doe <jdoe@machine.example>"
       )
     ]
@@ -166,14 +166,14 @@ parsesTextMailboxesSuccessfully =
 addresses :: IsString s => [(String, Either String Address -> Assertion, s)]
 addresses =
     [ ( "single address"
-      , (Right (Single (Mailbox Nothing (AddrSpec "foo" (DomainDotAtom $ pure "bar.com")))) @=?)
+      , (Right (Single (Mailbox Nothing (AddrSpec "foo" (DomainDotAtom $ "bar" :| ["com"])))) @=?)
       , "<foo@bar.com>")
     , ( "group of addresses"
       , (Right
              (Group
                   "Group"
-                  [ Mailbox (Just "Mr Foo") (AddrSpec "foo" (DomainDotAtom $ pure "bar.com"))
-                  , Mailbox (Just "Mr Bar") (AddrSpec "bar" (DomainDotAtom $ pure "bar.com"))]) @=?)
+                  [ Mailbox (Just "Mr Foo") (AddrSpec "foo" (DomainDotAtom $ "bar" :| ["com"]))
+                  , Mailbox (Just "Mr Bar") (AddrSpec "bar" (DomainDotAtom $ "bar" :| ["com"]))]) @=?)
       , "Group: \"Mr Foo\" <foo@bar.com>, \"Mr Bar\" <bar@bar.com>;")
     , ( "group of undisclosed recipients"
       , (Right (Group "undisclosed-recipients" []) @=?)
@@ -302,11 +302,6 @@ testReferencesField =
           set (at "message-id") (Just "messageid")
         , Just "references messageid")
       ]
-
-multipleMailboxes :: [Mailbox]
-multipleMailboxes =
-    [ Mailbox (Just "Mr Bar") (AddrSpec "bar" (DomainDotAtom $ pure "bar.com"))
-    , Mailbox Nothing (AddrSpec "roman" (DomainDotAtom $ pure "mail.test"))]
 
 -- | Generate headers
 genFieldItem :: Gen B.ByteString


### PR DESCRIPTION
```
f454f4c (Fraser Tweedale, 25 seconds ago)
   doc: show how to set To/From/Cc/Bcc

4758379 (Fraser Tweedale, 15 minutes ago)
   add tests for headerFrom/To/CC/BCC

f366d8c (Fraser Tweedale, 24 minutes ago)
   fix dot-atom parsing

   We were parsing dot-atoms into a (NonEmpty ByteString), but always as a
   singleton that included the whole name *with dots*.  Names were not broken
   up into fragments as they should be.

   Fix the parsing and update tests accordingly.

47d597c (Fraser Tweedale, 4 hours ago)
   fix From/To/Cc/Bcc header optics

   The headerFrom, headerTo, headerCC and headerBCC optics cannot be used to
   set the header if the header was not already present
   (because 'header k' is a Traversal).  Refactor these optics to use
   'at k' instead along with an Iso for converting between the 'Maybe 
   ByteString' and [a].

   Fixes: https://github.com/purebred-mua/purebred-email/issues/40
```