### PR TITLE
Add encodeEncodedWords function for creating headers with non-ASCII

### DIFF
--- a/purebred-email.cabal
+++ b/purebred-email.cabal
@@ -89,6 +89,7 @@ test-suite tests
   main-is: Test.hs
   other-modules:
     ContentTransferEncodings
+    , EncodedWord
     , Headers
     , MIME
     , Generator

--- a/src/Data/MIME/Base64.hs
+++ b/src/Data/MIME/Base64.hs
@@ -9,7 +9,8 @@ Implementation of Base64 Content-Transfer-Encoding.
 -}
 module Data.MIME.Base64
   (
-    contentTransferEncodeBase64
+    b
+  , contentTransferEncodeBase64
   , contentTransferEncodingBase64
   ) where
 
@@ -61,4 +62,9 @@ contentTransferDecodeBase64 = B64.decode . B.filter isBase64Char
 contentTransferEncodingBase64 :: ContentTransferEncoding
 contentTransferEncodingBase64 = prism'
   contentTransferEncodeBase64
+  (either (const Nothing) Just . contentTransferDecodeBase64)
+
+b :: ContentTransferEncoding
+b = prism'
+  B64.encode
   (either (const Nothing) Just . contentTransferDecodeBase64)

--- a/src/Data/MIME/EncodedWord.hs
+++ b/src/Data/MIME/EncodedWord.hs
@@ -9,16 +9,19 @@
 -}
 module Data.MIME.EncodedWord
   (
-    decodeEncodedWords
+    decodeEncodedWords,
+    encodeEncodedWords
   ) where
 
 import Control.Applicative ((<|>), liftA2, optional)
 import Data.Bifunctor (first)
 import Data.Semigroup ((<>))
+import Data.Monoid (Sum(Sum), Any(Any))
 
-import Control.Lens (to, clonePrism, review, view)
+import Control.Lens (to, clonePrism, review, view, foldMapOf)
 import Data.Attoparsec.ByteString
 import Data.Attoparsec.ByteString.Char8 (char8)
+import Data.ByteString.Lens (bytes)
 import qualified Data.ByteString as B
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as T
@@ -26,6 +29,7 @@ import qualified Data.Text.Encoding as T
 
 import Data.MIME.Charset
 import Data.MIME.TransferEncoding
+import Data.MIME.Base64
 import Data.MIME.QuotedPrintable
 import Data.RFC5322.Internal
 
@@ -144,3 +148,30 @@ decodeEncodedWords charsets s =
       (view (charsetDecoded charsets) w)
 
     merge = foldMap (either decodeLenient id)
+
+-- | This function encodes necessary parts of some text
+--
+-- Currently turns the whole text into a single encoded word, if necessary.
+encodeEncodedWords :: T.Text -> B.ByteString
+encodeEncodedWords s =
+  maybe
+  utf8
+  (uncurry ((serialiseEncodedWord .) . (. cteOf) . EncodedWord "utf-8" Nothing))
+  (chooseEncodedWordEncoding utf8)
+  where
+    cteOf cte = review (clonePrism cte) utf8
+    utf8 = T.encodeUtf8 s
+
+chooseEncodedWordEncoding :: B.ByteString -> Maybe (TransferEncodingName, TransferEncoding)
+chooseEncodedWordEncoding s
+  | not doEnc = Nothing
+  | nQP < nB64 = Just ("Q", q)
+  | otherwise = Just ("B", b)
+  where
+    -- https://tools.ietf.org/html/rfc5322#section-3.5 'text'
+    needEnc c = c > 127 || c == 0
+    qpBytes c
+      | encodingRequiredNonEOL Q c = 3
+      | otherwise = 1
+    (Any doEnc, Sum nQP) = foldMapOf bytes (\c -> (Any (needEnc c), Sum (qpBytes c))) s
+    nB64 = ((B.length s + 2) `div` 3) * 4

--- a/src/Data/MIME/TransferEncoding.hs
+++ b/src/Data/MIME/TransferEncoding.hs
@@ -103,7 +103,7 @@ transferEncodings =
   , ("quoted-printable", contentTransferEncodingQuotedPrintable)
   , ("base64", contentTransferEncodingBase64)
   , ("q", q)
-  , ("b", contentTransferEncodingBase64)
+  , ("b", b)
   ]
 
 -- | Inspect the data and choose a transfer encoding to use: @7bit@

--- a/tests/EncodedWord.hs
+++ b/tests/EncodedWord.hs
@@ -1,0 +1,18 @@
+module EncodedWord where
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.QuickCheck.Instances ()
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+import Data.MIME.Charset
+import Data.MIME.EncodedWord
+
+properties :: TestTree
+properties = localOption (QuickCheckMaxSize 1000) $
+  testProperty "encodeEncodedWords roundtrip" prop_roundtrip
+
+prop_roundtrip :: T.Text -> Bool
+prop_roundtrip t =
+  decodeEncodedWords defaultCharsets (encodeEncodedWords t) == t

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -2,6 +2,7 @@ import Test.Tasty
 import Test.Tasty.QuickCheck
 
 import ContentTransferEncodings as CTE
+import EncodedWord
 import MIME
 import Headers
 import Generator
@@ -12,6 +13,7 @@ main :: IO ()
 main =
   defaultMain $ testGroup "Tests"
     [ CTE.properties
+    , EncodedWord.properties
     , Headers.unittests
     , Generator.properties
     , MIME.unittests


### PR DESCRIPTION
Takes in the Text that you want in the header and returns either the
same text as an ASCII ByteString or an appropriate encoded-word that
will decode to the original.