### PR TITLE
support message types with no body or optional body

### DIFF
--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -34,7 +34,7 @@ renderSimpleMailSuccessfully =
         "renders simple mail"
         diffCommand
         "tests/golden/textplain7bit.golden"
-        (pure $ LB.fromStrict $ renderMessage textPlain7bit)
+        (pure $ renderMessage textPlain7bit)
 
 diffCommand :: FilePath -> FilePath -> [String]
 diffCommand ref new =
@@ -50,7 +50,7 @@ rendersMultiPartSuccessfully =
         "renders simple, multi-part mail"
         diffCommand
         "tests/golden/multipart.golden"
-        (pure $ LB.fromStrict $ renderMessage multiPartMail)
+        (pure $ renderMessage multiPartMail)
 
 exampleMailsParseSuccessfully :: TestTree
 exampleMailsParseSuccessfully =

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -14,15 +14,21 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+{-# LANGUAGE OverloadedStrings #-}
+
 module Parser where
+
+import Data.Either (isLeft)
 
 import Data.Attoparsec.ByteString.Lazy as AL
 import Data.ByteString as B
 import Data.ByteString.Lazy as L
 import Test.QuickCheck.Instances ()
 import Test.Tasty
+import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 
+import Data.RFC5322
 import Data.RFC5322.Internal (takeTillString)
 
 tests :: TestTree
@@ -36,4 +42,40 @@ tests = testGroup "Parser tests"
           case AL.parse (AL.string h *> takeTillString c) s' of
             AL.Done r' l' -> r' == L.fromStrict r && l' == l
             _ -> False
+  , testBodyParsing
   ]
+
+
+data Antibody = Antibody
+  deriving (Eq, Show)
+
+instance EqMessage Antibody
+
+data MaybeBody = NotPresent | Present B.ByteString
+  deriving (Eq, Show)
+
+instance EqMessage MaybeBody
+
+
+testBodyParsing :: TestTree
+testBodyParsing = testGroup "BodyHandler tests"
+  [ testCase "empty body" $
+      parseOnly (message (const $ NoBody Antibody) <* endOfInput) msg
+      @?= Right (Message hdrs Antibody)
+  , testCase "optional body (present, parses)" $
+      parseOnly (message opt <* endOfInput) (msg <> "\r\nyeah")
+      @?= Right (Message hdrs (Present "yeah"))
+  , testCase "optional body (present, no parse)" $
+      isLeft (parseOnly (message opt <* endOfInput) (msg <> "\r\nnah"))
+      @?= True
+  , testCase "optional body (present, empty)" $
+      isLeft (parseOnly (message opt <* endOfInput) (msg <> "\r\n"))
+      @?= True
+  , testCase "optional body (absent)" $
+      parseOnly (message opt <* endOfInput) msg
+      @?= Right (Message hdrs NotPresent)
+  ]
+  where
+    msg = "From: alice@example.net\r\n"
+    hdrs = Headers [("From", "alice@example.net")]
+    opt _ = OptionalBody (Present <$> AL.string "yeah", NotPresent)

--- a/tests/golden/multipart.golden
+++ b/tests/golden/multipart.golden
@@ -6,12 +6,14 @@ Subject: Hello there
 Content-Type: multipart/mixed; boundary=asdf
 
 --asdf
+MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Content-Disposition: inline
 Content-Type: text/plain; charset=us-ascii
 
 This is a simple mail.
 --asdf
+MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename=foo.bin
 Content-Type: application/octet-stream


### PR DESCRIPTION
```
e8488e0 (Fraser Tweedale, 5 minutes ago)
   support parsing messages with no body

   RFC 5322 and its predecessors define message as:

      message         =   (fields / obs-fields)
                         [CRLF body]

   The body is optional, and there is syntactic and semantic difference 
   between an empty body and a missing body.  Enhance purebred-email to 
   support parsing message types that do not have a body, or have an optional
   body.

   Also add a default implementation for EqMessage:

     default eqMessage :: (Eq a) => Message s a -> Message s a -> Bool

   Fixes: https://github.com/purebred-mua/purebred-email/issues/35

89c0c3a (Fraser Tweedale, 2 hours ago)
   generalise buildMessage and renderMessage

   buildMessage and renderMessage were specialised to MIME payloads. But to
   support other payload types using RFC 5322, generalise these methods over a
   new type class 'RenderMessage a'.  The class does admit message types
   without bodies so the rendering part of 
   https://github.com/purebred-mua/purebred-email/issues/35 is now done.

   Also change the type of 'renderMessage' to return /lazy/ ByteString. Strict
   ByteString is almost always *not* suitable.
```