### PR TITLE
headerDate when header not present, and parsing invalid header

### DIFF
--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -96,6 +96,7 @@ module Data.RFC5322
   -- * Helpers
   , field
   , rfc5422DateTimeFormat
+  , rfc5422DateTimeFormatLax
 
   -- * Serialisation
   , buildMessage
@@ -232,6 +233,9 @@ special = satisfy isSpecial
 -- Sat, 29 Sep 2018 12:51:05 +1000
 rfc5422DateTimeFormat :: String
 rfc5422DateTimeFormat = "%a, %d %b %Y %T %z"
+
+rfc5422DateTimeFormatLax :: String
+rfc5422DateTimeFormatLax = "%a, %-d %b %Y %-H:%-M:%-S %z"
 
 renderRFC5422Date :: UTCTime -> B.ByteString
 renderRFC5422Date = Char8.pack . formatTime defaultTimeLocale rfc5422DateTimeFormat


### PR DESCRIPTION
Fixes #46 so that Date header can be added when not already present (with test).

Fixes #16 so that invalid Date header results in Nothing and not bottom (with test).

Allow a slightly more lax version of dates for parsing.