### PR TITLE
Q encoding fixes

### DIFF
--- a/src/Data/MIME/QuotedPrintable.hs
+++ b/src/Data/MIME/QuotedPrintable.hs
@@ -37,12 +37,11 @@ data QuotedPrintableMode = QuotedPrintable | Q
 -- | Whether it is required to encode a character
 -- (where that character does not precede EOL).
 encodingRequiredNonEOL :: QuotedPrintableMode -> Word8 -> Bool
-encodingRequiredNonEOL mode c = not (
-  (c >= 33 && c <= 60)
-  || (c >= 62 && c <= 126)
-  || c == 9
-  || c == 32
-  ) || (mode == Q && c == 95 {- underscore -})
+encodingRequiredNonEOL mode c =
+  (c < 32 {- ' ' -} && c /= 9 {- \t -})
+  || c == 61 {- = -}
+  || c >= 127
+  || mode == Q && (c == 95 {- _ -} || c == 9 {- \t -})
 
 
 -- | Whether it is required to encode a character

--- a/src/Data/MIME/QuotedPrintable.hs
+++ b/src/Data/MIME/QuotedPrintable.hs
@@ -41,7 +41,7 @@ encodingRequiredNonEOL mode c =
   (c < 32 {- ' ' -} && c /= 9 {- \t -})
   || c == 61 {- = -}
   || c >= 127
-  || mode == Q && (c == 95 {- _ -} || c == 9 {- \t -})
+  || mode == Q && (c == 95 {- _ -} || c == 9 {- \t -} || c == 63 {- ? -})
 
 
 -- | Whether it is required to encode a character


### PR DESCRIPTION
```
a419c34 (Fraser Tweedale, 15 minutes ago)
   do not wrap lines in Q encoding

   Q encoding has a maximum length, but the way that Quoted-Printable encoding
   wraps lines is incorrect for Q encoding.  So punt on this problem: raise
   the wrap limit for Q encoding to (maxBound :: Int), to effectively prevent
   wrapping.

03614b9 (Fraser Tweedale, 20 minutes ago)
   encode '?' in Q encoding

   Q transfer encoding requires '?' (63, 0x3f) to be encoded, but this was not
   being done.  Make it so.

6e1890e (Fraser Tweedale, 20 minutes ago)
   encode '\t' in Q encoding

   Q transfer encoding requires HTAB ('\t'; 0x09) to be encoded, but this was
   not being done.  Make it so.
```