### PR TITLE
header folding: filter out empty lines

### DIFF
--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -402,7 +402,7 @@ buildField (k,v) =
 foldUnstructured :: Int -> B.ByteString -> B.ByteString
 foldUnstructured i b =
     let xs = chunk (i + 2) (Char8.words b) [] []
-    in B.intercalate "\r\n " xs
+    in B.intercalate "\r\n " (filter (not . B.null) xs)
 
 chunk :: Int -> [B.ByteString] -> [B.ByteString] -> [B.ByteString] -> [B.ByteString]
 chunk _ [] xs result = result <> [Char8.unwords xs]

--- a/tests/Headers.hs
+++ b/tests/Headers.hs
@@ -79,7 +79,7 @@ rendersFieldsSuccessfully =
           , "Subject: Re: Simple Subject\r\n")
         , ( "continuous line"
           , ("Subject", "ThisisalongcontiniousLineWithoutAnyWhiteSpaceandNowSomeGarbageASDFASDFASDFASDF")
-          , "Subject: \r\n ThisisalongcontiniousLineWithoutAnyWhiteSpaceandNowSomeGarbageASDFASDFASDFASDF\r\n")
+          , "Subject: ThisisalongcontiniousLineWithoutAnyWhiteSpaceandNowSomeGarbageASDFASDFASDFASDF\r\n")
         , ( "folding"
           , ( "Received"
             , "from adsl-33-138-215-182-129-129.test.example ([XX.XX.XXX.XXX]) by this.is.another.hostname.example with esmtp (Exim 4.24) id 1Akwaj-00035l-NT for me@test.example; Sun, 25 2004 21:35:09 -0500")


### PR DESCRIPTION
The header wrapping will wrap a long word to the next line, even if
it is the first word. This is legal, but a bit awkward and
unnecessary.  It also complicates header processing e.g. when the
initial datum is an encoded-word value, the interpretation includes
spurious leading whitespace.

Filter out empty folded lines to avoid this problem.