### PR TITLE
deps: base64-bytestring < 1.1

### DIFF
--- a/purebred-email.cabal
+++ b/purebred-email.cabal
@@ -67,7 +67,7 @@ library
   build-depends:
     base >= 4.11 && < 5
     , attoparsec >= 0.13 && < 0.14
-    , base64-bytestring >= 1 && < 2
+    , base64-bytestring >= 1 && < 1.1
     , bytestring >= 0.10 && < 0.11
     , case-insensitive >= 1.2 && < 1.3
     , concise >= 0.1.0.1 && < 1


### PR DESCRIPTION
base64-bytestring v1.1 removed 'joinWith', which we are using.  We
ought to avoid 'joinWith', but let's just lower the upper bound for
now.

Fixes: https://github.com/purebred-mua/purebred/issues/388