### PR TITLE
many wonderful changes (v0.5)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -32,10 +32,6 @@ jobs:
             allow-failure: false
           - ghc: 8.8.4
             allow-failure: false
-          - ghc: 8.6.5
-            allow-failure: false
-          - ghc: 8.4.4
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/purebred-email.cabal
+++ b/purebred-email.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                purebred-email
-version:             0.4.2
+version:             0.5.0
 synopsis:            types and parser for email messages (including MIME)
 description:
   The purebred email library.  RFC 5322, MIME, etc.

--- a/purebred-email.cabal
+++ b/purebred-email.cabal
@@ -23,7 +23,7 @@ license:             AGPL-3.0-or-later
 license-file:        LICENSE
 author:              Fraser Tweedale
 maintainer:          frase@frase.id.au
-copyright:           Copyright 2017-2019  Fraser Tweedale
+copyright:           Copyright 2017-2021  Fraser Tweedale
 category:            Data, Email
 build-type:          Simple
 extra-source-files:
@@ -31,7 +31,7 @@ extra-source-files:
   test-vectors/*.eml
   tests/golden/*.golden
 tested-with:
-  GHC ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
+  GHC ==8.8.4 || ==8.10.4 || ==9.0.1
 
 homepage:            https://github.com/purebred-mua/purebred-email
 bug-reports:         https://github.com/purebred-mua/purebred-email/issues
@@ -55,7 +55,7 @@ common common
     , lens >= 4 && < 6
     , semigroups >= 0.16
     , text >= 1.2
-    , time >= 1.8
+    , time >= 1.9
 
 library
   import: common
@@ -75,6 +75,7 @@ library
     , Data.MIME.QuotedPrintable
   other-modules:
     Data.MIME.Internal
+    , Data.RFC5322.DateTime
   -- other-extensions:    
   build-depends:
     , base64-bytestring >= 1 && < 2

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -125,8 +125,6 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import Data.Time.Clock (UTCTime)
-import Data.Time.Format (defaultTimeLocale, parseTimeM)
 
 import Data.RFC5322
 import Data.RFC5322.Internal hiding (takeWhile1)
@@ -854,12 +852,6 @@ headerTo, headerCC, headerBCC :: (HasHeaders a) => CharsetLookup -> Lens' a [Add
 headerTo = headerAddressList "To"
 headerCC = headerAddressList "Cc"
 headerBCC = headerAddressList "Bcc"
-
-headerDate :: HasHeaders a => Lens' a (Maybe UTCTime)
-headerDate = headers . at "Date" . iso (parseDate =<<) (fmap renderRFC5322Date)
-  where
-    parseDate =
-        parseTimeM True defaultTimeLocale rfc5322DateTimeFormatLax . C8.unpack
 
 -- | Single-valued header with @Text@ value via encoded-words.
 -- The conversion to/from Text is total (encoded-words that failed to be

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -856,10 +856,10 @@ headerCC = headerAddressList "Cc"
 headerBCC = headerAddressList "Bcc"
 
 headerDate :: HasHeaders a => Lens' a (Maybe UTCTime)
-headerDate = headers . at "Date" . iso (parseDate =<<) (fmap renderRFC5422Date)
+headerDate = headers . at "Date" . iso (parseDate =<<) (fmap renderRFC5322Date)
   where
     parseDate =
-        parseTimeM True defaultTimeLocale rfc5422DateTimeFormatLax . C8.unpack
+        parseTimeM True defaultTimeLocale rfc5322DateTimeFormatLax . C8.unpack
 
 -- | Single-valued header with @Text@ value via encoded-words.
 -- The conversion to/from Text is total (encoded-words that failed to be

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -845,7 +845,7 @@ createMultipartMixedMessage
     -> NonEmpty MIMEMessage -- ^ parts
     -> MIMEMessage
 createMultipartMixedMessage b attachments' =
-    let hdrs = mempty &
+    let hdrs = Headers [] &
                 set contentType (contentTypeMultipartMixed b)
     in Message hdrs (Multipart attachments')
 
@@ -856,7 +856,7 @@ createTextPlainMessage s = fmap Part $ transferEncode $ charsetEncode msg
   where
   msg = Message hdrs s :: TextEntity
   cd = ContentDisposition Inline mempty
-  hdrs = mempty
+  hdrs = Headers []
           & set contentType contentTypeTextPlain
           & set contentDisposition (Just cd)
 
@@ -876,7 +876,7 @@ createAttachment ct fp s = Part <$> transferEncode msg
   msg = Message hdrs s
   cd = ContentDisposition Attachment cdParams
   cdParams = mempty & set filenameParameter (newParameter <$> fp)
-  hdrs = mempty
+  hdrs = Headers []
           & set contentType ct
           & set contentDisposition (Just cd)
 
@@ -886,4 +886,4 @@ createAttachment ct fp s = Part <$> transferEncode msg
 encapsulate :: MIMEMessage -> MIMEMessage
 encapsulate = Message hdrs . Encapsulated
   where
-  hdrs = mempty & set contentType "message/rfc822"
+  hdrs = Headers [] & set contentType "message/rfc822"

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -91,6 +91,7 @@ module Data.MIME
 
   -- *** Reply
   , replyHeaderReferences
+  , setTextPlainBody
 
   -- *** Forward
   , encapsulate
@@ -852,13 +853,18 @@ createMultipartMixedMessage b attachments' =
 -- | Create an inline, text/plain, utf-8 encoded message
 --
 createTextPlainMessage :: T.Text -> MIMEMessage
-createTextPlainMessage s = fmap Part $ transferEncode $ charsetEncode msg
-  where
-  msg = Message hdrs s :: TextEntity
-  cd = ContentDisposition Inline mempty
-  hdrs = Headers []
-          & set contentType contentTypeTextPlain
-          & set contentDisposition (Just cd)
+createTextPlainMessage s = setTextPlainBody s (Message (Headers []) ())
+
+-- | Set an inline, @text/plain@, utf-8 encoded message body
+--
+setTextPlainBody :: T.Text -> Message ctx a -> MIMEMessage
+setTextPlainBody s =
+  fmap Part
+  . transferEncode
+  . charsetEncode
+  . set contentDisposition (Just $ ContentDisposition Inline mempty)
+  . set contentType contentTypeTextPlain
+  . set body s
 
 -- | Create an attachment from a given file path.
 -- Note: The filename content disposition is set to the given `FilePath`. For

--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -170,12 +170,6 @@ type Header = (CI B.ByteString, B.ByteString)
 newtype Headers = Headers [Header]
   deriving (Eq, Show, Generic, NFData)
 
-instance Semigroup Headers where
-  Headers a <> Headers b = Headers (a <> b)
-
-instance Monoid Headers where
-  mempty = Headers []
-
 class HasHeaders a where
   headers :: Lens' a Headers
 

--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -77,6 +77,9 @@ module Data.RFC5322
   , headerList
   , Headers(..)
 
+  -- ** Date and Time
+  , dateTime
+
   -- ** Addresses
   , Address(..)
   , address
@@ -133,8 +136,7 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Builder.Prim as Prim
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import Data.Time.Clock (UTCTime)
-import Data.Time.Format (defaultTimeLocale, formatTime)
+import Data.Time (UTCTime, defaultTimeLocale, formatTime)
 
 import Data.RFC5322.Internal
   ( CI, ci, original
@@ -143,6 +145,7 @@ import Data.RFC5322.Internal
   , optionalCFWS, word, wsp, vchar, optionalFWS, crlf
   , domainLiteral, dotAtom, localPart, quotedString
   )
+import Data.RFC5322.DateTime (dateTime)
 import Data.RFC5322.Address.Types
 import Data.MIME.Charset
 import Data.MIME.EncodedWord (encodedWord, decodeEncodedWord, buildEncodedWord)

--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -83,6 +83,7 @@ module Data.RFC5322
 
   -- *** Originator
   , headerFrom
+  , headerReplyTo
 
   -- *** Destination Address
   , headerTo
@@ -414,19 +415,17 @@ headerSingleToList
 headerSingleToList f g k =
   headers . at k . iso (maybe [] f) (\l -> if null l then Nothing else Just (g l))
 
-headerFrom :: HasHeaders a => CharsetLookup -> Lens' a [Mailbox]
-headerFrom charsets = headerSingleToList
-  (fromRight [] . parseOnly (mailboxList charsets))
-  renderMailboxes
-  "From"
-
 headerAddressList :: (HasHeaders a) => CI B.ByteString -> CharsetLookup -> Lens' a [Address]
 headerAddressList k charsets = headerSingleToList
   (fromRight [] . parseOnly (addressList charsets))
   renderAddresses
   k
 
-headerTo, headerCC, headerBCC :: (HasHeaders a) => CharsetLookup -> Lens' a [Address]
+headerFrom, headerReplyTo, headerTo, headerCC, headerBCC
+  :: (HasHeaders a)
+  => CharsetLookup -> Lens' a [Address]
+headerFrom = headerAddressList "From"
+headerReplyTo = headerAddressList "Reply-To"
 headerTo = headerAddressList "To"
 headerCC = headerAddressList "Cc"
 headerBCC = headerAddressList "Bcc"

--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -96,14 +96,14 @@ module Data.RFC5322
 
   -- * Helpers
   , field
-  , rfc5422DateTimeFormat
-  , rfc5422DateTimeFormatLax
+  , rfc5322DateTimeFormat
+  , rfc5322DateTimeFormatLax
 
   -- * Serialisation
   , buildMessage
   , renderMessage
   , RenderMessage(..)
-  , renderRFC5422Date
+  , renderRFC5322Date
   , buildFields
   , buildField
   , renderAddressSpec
@@ -241,14 +241,14 @@ special = satisfy isSpecial
 
 -- §3.3  Date and Time Specification
 -- Sat, 29 Sep 2018 12:51:05 +1000
-rfc5422DateTimeFormat :: String
-rfc5422DateTimeFormat = "%a, %d %b %Y %T %z"
+rfc5322DateTimeFormat :: String
+rfc5322DateTimeFormat = "%a, %d %b %Y %T %z"
 
-rfc5422DateTimeFormatLax :: String
-rfc5422DateTimeFormatLax = "%a, %-d %b %Y %-H:%-M:%-S %z"
+rfc5322DateTimeFormatLax :: String
+rfc5322DateTimeFormatLax = "%a, %-d %b %Y %-H:%-M:%-S %z"
 
-renderRFC5422Date :: UTCTime -> B.ByteString
-renderRFC5422Date = Char8.pack . formatTime defaultTimeLocale rfc5422DateTimeFormat
+renderRFC5322Date :: UTCTime -> B.ByteString
+renderRFC5322Date = Char8.pack . formatTime defaultTimeLocale rfc5322DateTimeFormat
 
 -- §3.4 Address Specification
 buildMailbox :: Mailbox -> Builder.Builder

--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -73,7 +73,6 @@ module Data.RFC5322
   -- * Headers
   , Header
   , HasHeaders(..)
-  , header
   , headerList
   , Headers(..)
 
@@ -99,9 +98,18 @@ module Data.RFC5322
   , headerSubject
 
   -- ** Arbitrary headers
+  , header
   , headerText
 
-  -- * Address types
+  -- * Types
+
+  -- ** Message ID
+  , MessageID
+  , parseMessageID
+  , buildMessageID
+  , renderMessageID
+
+  -- ** Address types
   , Address(..)
   , address
   , addressList
@@ -445,6 +453,9 @@ data MessageID = MessageID
   (Either (NonEmpty B.ByteString) B.ByteString)
   deriving (Eq, Ord)
 
+instance Show MessageID where
+  show = Char8.unpack . renderMessageID
+
 parseMessageID :: Parser MessageID
 parseMessageID =
   MessageID
@@ -488,8 +499,6 @@ headerReferences = headerMessageIDList "References"
 -- The conversion to/from Text is total (encoded-words that failed to be
 -- decoded are passed through unchanged).  Therefore @Nothing@ means that
 -- the header was not present.
---
--- This function is suitable for the @Subject@ header.
 --
 headerText :: (HasHeaders a) => CharsetLookup -> CI B.ByteString -> Lens' a (Maybe T.Text)
 headerText charsets k =

--- a/src/Data/RFC5322.hs
+++ b/src/Data/RFC5322.hs
@@ -384,7 +384,8 @@ buildAddressSpec (AddrSpec lp (DomainDotAtom b))
   | otherwise = buildLP <> rest
   where
     buildLP = Builder.byteString lp
-    rest = "@" <> foldMap Builder.byteString (Data.List.NonEmpty.intersperse "." b)
+    rest = "@" <> foldMap (Builder.byteString . original)
+                          (Data.List.NonEmpty.intersperse "." b)
 buildAddressSpec (AddrSpec lp (DomainLiteral b)) =
   foldMap Builder.byteString [lp, "@", b]
 
@@ -399,7 +400,7 @@ isDtext :: Word8 -> Bool
 isDtext c = (c >= 33 && c <= 90) || (c >= 94 && c <= 126)
 
 domain :: Parser Domain
-domain = (DomainDotAtom <$> dotAtom)
+domain = (DomainDotAtom . fmap mk <$> dotAtom)
          <|> (DomainLiteral <$> domainLiteral)
 
 mailboxList :: CharsetLookup -> Parser [Mailbox]

--- a/src/Data/RFC5322/Address/Text.hs
+++ b/src/Data/RFC5322/Address/Text.hs
@@ -8,6 +8,7 @@ module Data.RFC5322.Address.Text
   (
     mailbox
   , mailboxList
+  , readMailbox
   , address
   , addressList
   -- * Pretty printing
@@ -77,6 +78,10 @@ renderAddressSpec = LT.toStrict . Builder.toLazyText . buildAddressSpec
 mailbox :: Parser Mailbox
 mailbox = Mailbox <$> optional displayName <*> angleAddr
           <|> Mailbox Nothing <$> addressSpec
+
+-- | Parse a (whole) string, returning an error @String@ or a 'Mailbox'.
+readMailbox :: String -> Either String Mailbox
+readMailbox = parseOnly (mailbox <* endOfInput) . T.pack
 
 -- | Version of 'phrase' that does not process encoded-word
 -- (we are parsing Text so will assume that the input does not

--- a/src/Data/RFC5322/Address/Text.hs
+++ b/src/Data/RFC5322/Address/Text.hs
@@ -26,7 +26,7 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Internal.Builder as Builder
 import qualified Data.ByteString as B
-import Data.Attoparsec.Text as A hiding (parse, take)
+import Data.Attoparsec.Text as A hiding (char, parse, take)
 import Data.List.NonEmpty (intersperse)
 
 import Data.MIME.Charset (decodeLenient)

--- a/src/Data/RFC5322/Address/Text.hs-boot
+++ b/src/Data/RFC5322/Address/Text.hs-boot
@@ -1,0 +1,5 @@
+module Data.RFC5322.Address.Text where
+
+import {-# SOURCE #-} Data.RFC5322.Address.Types
+
+readMailbox :: String -> Either String Mailbox

--- a/src/Data/RFC5322/Address/Types.hs
+++ b/src/Data/RFC5322/Address/Types.hs
@@ -10,12 +10,15 @@ module Data.RFC5322.Address.Types
   ) where
 
 import Control.DeepSeq (NFData)
+import Data.String (IsString(..))
 import qualified Data.Text as T
 import qualified Data.ByteString as B
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
 
 import Data.CaseInsensitive
+
+import {-# SOURCE #-} Data.RFC5322.Address.Text (readMailbox)
 
 -- | Email address with optional display name.
 -- The @Eq@ instance compares the display name case
@@ -25,6 +28,10 @@ data Mailbox =
     Mailbox (Maybe T.Text {- display name -})
              AddrSpec
     deriving (Show, Eq, Generic, NFData)
+
+instance IsString Mailbox where
+  fromString =
+    either (error . mappend "Failed to parse Mailbox: ") id . readMailbox
 
 -- | Email address.  The @Eq@ instances compares the local part
 -- case sensitively, and the domain part as described at 'Domain'.

--- a/src/Data/RFC5322/Address/Types.hs
+++ b/src/Data/RFC5322/Address/Types.hs
@@ -15,11 +15,26 @@ import qualified Data.ByteString as B
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
 
+import Data.CaseInsensitive
+
+-- | Email address with optional display name.
+-- The @Eq@ instance compares the display name case
+-- sensitively and the address as described at 'AddrSpec'.
+--
 data Mailbox =
     Mailbox (Maybe T.Text {- display name -})
              AddrSpec
     deriving (Show, Eq, Generic, NFData)
 
+-- | Email address.  The @Eq@ instances compares the local part
+-- case sensitively, and the domain part as described at 'Domain'.
+--
+-- Address "detail" (section of local part after a @'+'@ character;
+-- also called "extension" or "subaddress") is part of the local
+-- part.  Therefore addresses that differ in this aspect, for
+-- example @alice+bank\@example.com@ and @alice+spam\@example.com@,
+-- are unequal.
+--
 data AddrSpec =
     AddrSpec B.ByteString {- local part -}
              Domain
@@ -31,7 +46,9 @@ data Address
             [Mailbox]
     deriving (Show, Eq, Generic, NFData)
 
+-- | A DNS name or "domain literal" (address literal).
+-- DNS names are compared case-insensitively.
 data Domain
-    = DomainDotAtom (NonEmpty B.ByteString {- printable ascii -})
+    = DomainDotAtom (NonEmpty (CI B.ByteString) {- printable ascii -})
     | DomainLiteral B.ByteString
     deriving (Show, Eq, Generic, NFData)

--- a/src/Data/RFC5322/Address/Types.hs-boot
+++ b/src/Data/RFC5322/Address/Types.hs-boot
@@ -1,0 +1,3 @@
+module Data.RFC5322.Address.Types where
+
+data Mailbox

--- a/src/Data/RFC5322/DateTime.hs
+++ b/src/Data/RFC5322/DateTime.hs
@@ -1,0 +1,141 @@
+-- This file is part of purebred-email
+-- Copyright (C) 2021  Fraser Tweedale
+--
+-- purebred-email is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Data.RFC5322.DateTime
+  ( dateTime
+  ) where
+
+import Control.Applicative ((<|>), optional)
+import Data.Functor (($>))
+
+import Data.Attoparsec.ByteString as A
+import Data.Attoparsec.ByteString.Char8 (char8, isDigit_w8)
+import qualified Data.ByteString as B
+import qualified Data.Time
+import Data.Time
+  ( Day, DayOfWeek(..), LocalTime(LocalTime), TimeOfDay, TimeZone
+  , ZonedTime(ZonedTime), fromGregorianValid, makeTimeOfDayValid
+  , minutesToTimeZone
+  )
+import Data.RFC5322.Internal (fws, optionalCFWS, optionalFWS)
+
+dateTime :: Parser ZonedTime
+dateTime = do
+  dow <- optional (dayOfWeek <* char8 ',')
+  theDate <- date
+
+  -- ensure day of week matches date
+  case dow of
+    Just dow' | Data.Time.dayOfWeek theDate /= dow'
+      -> fail "day of week inconsistent with date"
+    _ -> pure ()
+
+  tod <- timeOfDay
+  z <- zone
+  _ <- optionalCFWS
+
+  pure $ ZonedTime (LocalTime theDate tod) z
+
+
+dayOfWeek :: Parser DayOfWeek
+dayOfWeek = optionalFWS *> dayName
+
+dayName :: Parser DayOfWeek
+dayName =
+  string "Mon" $> Monday
+  <|> string "Tue" $> Tuesday
+  <|> string "Wed" $> Wednesday
+  <|> string "Thu" $> Thursday
+  <|> string "Fri" $> Friday
+  <|> string "Sat" $> Saturday
+  <|> string "Sun" $> Sunday
+  <|> fail "invalid day-of-week"
+
+date :: Parser Day
+date = do
+  d <- day
+  m <- month
+  y <- year
+  case fromGregorianValid y m d of
+    Just r -> pure r
+    Nothing -> fail "invalid date"
+
+day :: Parser Int
+day = optionalFWS *> go <* fws
+  where
+  go = (twoDigit <|> digit) >>= check (\n -> n > 0 && n <= 31) "day out of range"
+
+month :: Parser Int
+month =
+  string "Jan" $> 1
+  <|> string "Feb" $> 2
+  <|> string "Mar" $> 3
+  <|> string "Apr" $> 4
+  <|> string "May" $> 5
+  <|> string "Jun" $> 6
+  <|> string "Jul" $> 7
+  <|> string "Aug" $> 8
+  <|> string "Sep" $> 9
+  <|> string "Oct" $> 10
+  <|> string "Nov" $> 11
+  <|> string "Dec" $> 12
+  <|> fail "invalid month"
+
+year :: Parser Integer
+year = fws *> go <* fws
+  where
+  go = do
+    digits <- A.takeWhile isDigit_w8
+    guardFail (B.length digits >= 4) "too few digits in year"
+    let y = B.foldl' step 0 digits
+    guardFail (y >= 1900) "year cannot be < 1900" $> y
+  step r a = r * 10 + fromIntegral (a - 48)
+
+timeOfDay :: Parser TimeOfDay
+timeOfDay = do
+  hour <- twoDigit
+  _ <- char8 ':'
+  minute <- twoDigit
+  second <- char8 ':' *> twoDigit <|> pure 0
+  case makeTimeOfDayValid hour minute (fromIntegral second) of
+    Nothing -> fail "invalid time-of-day"
+    Just tod -> pure tod
+
+zone :: Parser TimeZone
+zone = fws *> go
+  where
+  go = do
+    posNeg <- char8 '+' $> id <|> char8 '-' $> negate
+    h <- twoDigit
+    m <- twoDigit
+    guardFail (m <= 59) "zone minutes must be in range 0..59"
+    pure $ minutesToTimeZone (posNeg (h * 60 + m))
+
+
+guardFail :: Bool -> String -> Parser ()
+guardFail True _ = pure ()
+guardFail False s = fail s
+
+check :: (a -> Bool) -> String -> a -> Parser a
+check f s a = guardFail (f a) s $> a
+
+digit :: Parser Int
+digit = (\c -> fromIntegral (c - 48)) <$> satisfy isDigit_w8
+
+twoDigit :: Parser Int
+twoDigit = (\hi lo -> hi * 10 + lo) <$> digit <*> digit

--- a/src/Data/RFC5322/Internal.hs
+++ b/src/Data/RFC5322/Internal.hs
@@ -14,6 +14,7 @@ module Data.RFC5322.Internal
 
   -- * Abstract character parsers
   , wsp
+  , fws
   , optionalFWS
   , optionalCFWS
   , crlf
@@ -166,6 +167,8 @@ crlf = void ((char '\r' *> char '\n') <|> char '\n')
 -- white space (not simply WSP characters), a CRLF may be inserted before any
 -- WSP."
 
+-- | Folding white space (FWS).  A run of one or more whitespace
+-- characters.  Returns a single SPACE character.
 fws :: (Alternative (f s), CharParsing f s a) => (f s) s
 fws = ( optional (takeWhile isWsp *> crlf) *> takeWhile1 isWsp )
       $> singleton ' '

--- a/src/Data/RFC5322/Internal.hs
+++ b/src/Data/RFC5322/Internal.hs
@@ -21,10 +21,12 @@ module Data.RFC5322.Internal
   , vchar
   , word
   , quotedString
+  , dotAtomText
   , dotAtom
   , localPart
   , domainLiteral
   , IsChar(..)
+  , char
   , CharParsing(..)
   , SM
 

--- a/src/Data/RFC5322/Internal.hs
+++ b/src/Data/RFC5322/Internal.hs
@@ -10,6 +10,7 @@ module Data.RFC5322.Internal
   -- * Case-insensitive value parsers
     ci
   , CI
+  , mk
   , original
 
   -- * Abstract character parsers

--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -11,9 +11,7 @@ import Test.Tasty.HUnit ((@=?), testCase)
 import Test.Tasty.Golden (goldenVsStringDiff)
 import Control.Lens (over, (&), set, at)
 import qualified Data.Text.Encoding as T
-import qualified Data.ByteString.Lazy as LB
-import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
-import Data.Time.Calendar (Day(..))
+import Data.Time (Day(..), UTCTime(..), secondsToDiffTime, utc, utcToZonedTime)
 
 import qualified Data.CaseInsensitive as CI
 
@@ -76,7 +74,8 @@ multiPartMail =
                 contentTypeApplicationOctetStream
                 (Just "foo.bin")
                 "fileContentsASDF"
-        now = UTCTime (ModifiedJulianDay 123) (secondsToDiffTime 123)
+        nowUTC = UTCTime (ModifiedJulianDay 123) (secondsToDiffTime 123)
+        now = utcToZonedTime utc nowUTC
     in createMultipartMixedMessage "asdf" (fromList [p, a])
        & set (headers . at "From") (Just $ renderMailboxes [from'])
        . set (headers . at "To") (Just $ renderAddresses [to'])

--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -80,5 +80,5 @@ multiPartMail =
     in createMultipartMixedMessage "asdf" (fromList [p, a])
        & set (headers . at "From") (Just $ renderMailboxes [from'])
        . set (headers . at "To") (Just $ renderAddresses [to'])
-       . set (headers . at "Date") (Just $ renderRFC5422Date now)
+       . set (headers . at "Date") (Just $ renderRFC5322Date now)
        . set (headers . at "Subject") (Just $ T.encodeUtf8 subject)

--- a/tests/Headers.hs
+++ b/tests/Headers.hs
@@ -404,12 +404,8 @@ crlfLines = go ""
         "\r\n"  -> acc <> h : go "" (L.drop 2 t)
         _       -> go (acc <> h <> L.take 1 t) (L.drop 1 t)
 
-at_example_com :: B.ByteString -> Mailbox
-at_example_com localPart =
-  Mailbox Nothing (AddrSpec localPart (DomainDotAtom ("example" :| ["com"])))
-
 alice, bob, carol, frank :: Mailbox
-alice = at_example_com "alice"
-bob = at_example_com "bob"
-carol = at_example_com "carol"
-frank = at_example_com "frank"
+alice = "alice@example.com"
+bob = "bob@example.com"
+carol = "carol@example.com"
+frank = "frank@example.com"

--- a/tests/Headers.hs
+++ b/tests/Headers.hs
@@ -320,6 +320,14 @@ testReply =
         view (headerTo defaultCharsets) rep_ReplyTo @?= [Single frank]
     ]
   where
+    mkSettings = ReplySettings
+      ReplyToSender
+      ReplyFromMatchingMailbox
+      ReplyFromRewriteOn
+      SelfInRecipientsRemove
+    bobSettings   = mkSettings (pure bob) & set replyMode ReplyToGroup
+    carolSettings = mkSettings (pure carol)
+
     extraMsgId = (\(Right a) -> a) $ parseOnly parseMessageID "<extra@host>"
 
     msg1ID = (\(Right a) -> a) $ parseOnly parseMessageID "<msg1@host>"
@@ -331,27 +339,27 @@ testReply =
       . set (headerCC defaultCharsets) [Single frank]
 
     rep1ID = (\(Right a) -> a) $ parseOnly parseMessageID "<rep1@host>"
-    rep1 = reply defaultCharsets GroupReply [bob] msg1
+    rep1 = reply defaultCharsets bobSettings msg1
       & set headerMessageID (Just rep1ID)
 
     rep2ID = (\(Right a) -> a) $ parseOnly parseMessageID "<rep2@host>"
-    rep2 = reply defaultCharsets SenderReply [carol] rep1
+    rep2 = reply defaultCharsets carolSettings rep1
       & set headerMessageID (Just rep2ID)
 
     -- reply to a message with no References + single-valued In-Reply_To
     rep_noRef_IRT =
-      reply defaultCharsets SenderReply [carol] (set headerReferences [] rep1)
+      reply defaultCharsets carolSettings (set headerReferences [] rep1)
 
     -- reply to a message with no References + multi-valued In-Reply_To
     rep_noRef_2IRT =
-      reply defaultCharsets SenderReply [carol] $
+      reply defaultCharsets carolSettings $
         rep1
           & set headerReferences []
           & over headerInReplyTo (extraMsgId:)
 
     -- reply to a message with Reply-To header set
     rep_ReplyTo =
-      reply defaultCharsets SenderReply [bob]
+      reply defaultCharsets carolSettings
         (set (headerReplyTo defaultCharsets) [Single frank] msg1)
 
 

--- a/tests/Headers.hs
+++ b/tests/Headers.hs
@@ -53,13 +53,13 @@ testFromToCcBccOptics = testGroup "headerFrom/To/Cc/Bcc tests" $
     bob = Mailbox Nothing (AddrSpec "bob" (DomainDotAtom ("example" :| ["com"])))
     carol = Mailbox Nothing (AddrSpec "carol" (DomainDotAtom ("example" :| ["com"])))
     msg = createTextPlainMessage "hi"
-    fromAlice = set (headerFrom defaultCharsets) [alice] msg
+    fromAlice = set (headerFrom defaultCharsets) [Single alice] msg
     fromAliceToBob = set (headerTo defaultCharsets) [Single bob] fromAlice
     fromAliceToCarolAndBob = over (headerTo defaultCharsets) (Single carol :) fromAliceToBob
   in
     [ testCase "From empty" $ view (headerFrom defaultCharsets) msg @?= []
     , testCase "To empty" $ view (headerTo defaultCharsets) msg @?= []
-    , testCase "set From alice" $ view (headerFrom defaultCharsets) fromAlice @?= [alice]
+    , testCase "set From alice" $ view (headerFrom defaultCharsets) fromAlice @?= [Single alice]
     , testCase "set To bob" $ view (headerTo defaultCharsets) fromAliceToBob @?= [Single bob]
     , testCase "add To carol" $ view (headerTo defaultCharsets) fromAliceToCarolAndBob @?= [Single carol, Single bob]
     , testCase "removing header" $ has (header "From") (set (headerFrom defaultCharsets) [] fromAlice) @?= False

--- a/tests/MIME.hs
+++ b/tests/MIME.hs
@@ -200,6 +200,10 @@ testOptics = testGroup "optics tests"
       testHeaderDateGet
       "Thu, 4 May 2017 03:08:43 +0000"
       (Just $ read "2017-05-04 03:08:43 UTC")
+  , testCase "headerDate get valid date with comment" $
+      testHeaderDateGet
+      "Fri, 15 Jan 2021 18:17:11 -0500 (EST)"
+      (Just $ read "2021-01-15 18:17:11 EST")
   , testCase "headerDate get invalid date" $
       testHeaderDateGet
       "Thu, 4 NOTMAY 2017 03:08:43 +0000"

--- a/tests/Message.hs
+++ b/tests/Message.hs
@@ -103,7 +103,7 @@ prop_messageRoundTrip = property $ do
 
 prop_messageFromRoundTrip :: Property
 prop_messageFromRoundTrip = property $ do
-  from <- forAll genMailbox
+  from <- Single <$> forAll genMailbox
   let
     l = headerFrom defaultCharsets
     msg = set l [from] (createTextPlainMessage "Hello")

--- a/tests/Message.hs
+++ b/tests/Message.hs
@@ -31,6 +31,7 @@ import Data.List.NonEmpty (NonEmpty(..), intersperse)
 
 import Control.Lens (set, view)
 import qualified Data.ByteString as B
+import Data.CaseInsensitive
 import qualified Data.Text as T
 
 import Test.Tasty
@@ -110,7 +111,7 @@ prop_messageFromRoundTrip = property $ do
   (view l <$> parse (message mime) (renderMessage msg)) === Right [from]
 
 genDomain :: Gen Domain
-genDomain = DomainDotAtom <$> genDotAtom -- TODO domain literal
+genDomain = DomainDotAtom . fmap mk <$> genDotAtom -- TODO domain literal
 
 genDotAtom :: Gen (NonEmpty B.ByteString)
 genDotAtom = Gen.nonEmpty (Range.linear 1 5) (Gen.utf8 (Range.linear 1 20) (Gen.filter isAtext Gen.ascii))

--- a/tests/Parser.hs
+++ b/tests/Parser.hs
@@ -133,7 +133,7 @@ testDateTimeParsing = testGroup "dateTime parsing" $
         isLeft (go "Sun, 03 Joo 2021 20:16:00 +1000")
         @?= True
     , testCase "bad (year insufficient digits)" $
-        isLeft (go "Wed, 03 Jan 899 20:16:00 +1000")
+        isLeft (go "03 Jan 9 20:16:00 +1000")
         @?= True
     , testCase "bad (year < 1900)" $
         isLeft (go "Sun, 03 Jan 1899 20:16:00 +1000")
@@ -166,4 +166,16 @@ testDateTimeParsing = testGroup "dateTime parsing" $
     , testCase "bad (obs-zone grammar)" $
         all (isLeft . go) (("Sun, 03 Jan 2021 20:16:00 " <>) <$> ["UTC", "CET", "AEST", "J"])
         @?= True
+    , testCase "good (obs-year 2 digit)" $
+        go "Sun, 03 Jan 21 20:16:00 +1000"
+        @?= Right now
+    , testCase "good (obs-year 3 digit)" $
+        go "Sun, 03 Jan 121 20:16:00 +1000"
+        @?= Right now
+    , testCase "good (obs-year 2 digit 2049)" $
+        go "Sun, 03 Jan 49 20:16:60 +1000"
+        @?= Right (explode $ read "2049-01-03 20:16:60 +1000")
+    , testCase "good (obs-year 2 digit 1950)" $
+        go "Tue, 03 Jan 50 20:16:60 +1000"
+        @?= Right (explode $ read "1950-01-03 20:16:60 +1000")
     ]


### PR DESCRIPTION
Highlights:

- A new `reply` function, for constructing replies.  Behaviour is
  configurable via the `ReplySettings` type.  This supports the
  reply and reply-all/group-reply functions in purebred, but replying
  is a general concept, the rules/guidelines for construction are written
  in RFC 5322, and so this behaviour belongs here in *purebred-email*.

- Proper `MessageID` type; parsing, serialisation and optics for `Message-ID`,
  `In-Reply-To` and `References` headers.

- More correct handling of Date header (#49)

- Implement RFC 6854 changes to `From` and `Sender` header syntax (#53)

- Add `instance IsString Mailbox` (#18)

- Compare domain names in addresses case-insensitively.


```
Changes:

26b2090 (Fraser Tweedale, 2 hours ago)
   ci: test with GHC 8.8 .. 9.0

   GHC < 8.8 has too-old version of time.  This is not a fundamental 
   compatibility problem with earlier releases, but it requires annoying hacks
   for CI.  So only test on 8.8 up.

   Also add 9.0.1 to the matrix.  It requires head.hackage because patched
   version of hedgehog is required.

94e852c (Fraser Tweedale, 4 hours ago)
   reply: avoid duplicate messages in To and Cc

   In ReplyToGroup mode, if the parent message includes its sender in both the
   From and To/Cc fields, then that address will appear in the To and Cc
   fields of the reply.  This is redundant.  Update the
   `reply` function to eliminate redundancy across the To and Cc headers.

1616d19 (Fraser Tweedale, 2 days ago)
   reply: implement ReplyFromMode and ReplyFromRewriteMode

e60f968 (Fraser Tweedale, 3 days ago)
   reply: implement SelfInRecipientsMode

17adc89 (Fraser Tweedale, 3 days ago)
   add instance IsString Mailbox

   Fixes: https://github.com/purebred-mua/purebred-email/issues/18

8e1a621 (Fraser Tweedale, 6 days ago)
   compare domain names in address case-insensitively

4378d5e (Fraser Tweedale, 6 days ago)
   add ReplySettings

   Add the `ReplySettings` data type.  It encapsulates several settings 
   related to reply construction, including:

   - author mailboxes

   - reply mode (the already existing `ReplyMode` type)

   - whether to use author address as it appears in parent message, or
    preferred mailbox

   - whether to rewrite matching author address to the variant in
    author mailboxes

   - whether or not to remove own address from recipients of reply

   This commit just chases the API change, and doesn't implement any of the
   additional functionality.

abb465c (Fraser Tweedale, 7 days ago)
   add 'reply' function

   Add 'reply' function for replying to a message.  This function follows the
   requirements and suggestions of RFC 5322 in setting the headers of the new
   message.  It does not set the body.

       reply :: CharsetLookup
        -> ReplyMode
        -> [Mailbox]
        -> Message ctx a
        -> Message ctx ()

ade4d64 (Fraser Tweedale, 7 days ago)
   export MessageID types; instance Show MessageID

2884628 (Fraser Tweedale, 7 days ago)
   add optics for Message-ID, In-Reply-To and References

b1ecbd7 (Fraser Tweedale, 7 days ago)
   add setTextPlainBody helper function

   It can be useful to just replace an entire message body.  Add a new helper
   function to do that:

     setTextPlainBody :: T.Text -> Message ctx a -> MIMEMessage

   Also refactor 'createTextPlainMessage' to use the new function.

b756752 (Fraser Tweedale, 7 days ago)
   remove Semigroup and Monoid instances for Header

   Although 'mempty' is handy, the Semigroup instance makes little sense for
   Headers.  It is easy to violate header cardinality and ordering
   requirements.  Remove the instances.

6639e5c (Fraser Tweedale, 8 days ago)
   implement RFC 6854 (address syntax in From: and Sender:)

   Fixes: https://github.com/purebred-mua/purebred-email/issues/53

1f0d857 (Fraser Tweedale, 8 days ago)
   move header optics to Data.RFC5322

   Headers that are defined in RFC 5322 should be implemented in and exported
   from module Data.RFC5322.  Make it so.

0df4faf (Fraser Tweedale, 7 weeks ago)
   become v0.5.0

ce46d57 (Fraser Tweedale, 7 weeks ago)
   RFC5322: implement obsolete year parsing

e1596a2 (Fraser Tweedale, 7 weeks ago)
   RFC5322: implement obsolete timezone parsing

a1f3801 (Fraser Tweedale, 8 weeks ago)
   RFC5322: add more date parsing tests

   Part of: https://github.com/purebred-mua/purebred-email/issues/49

ece38c4 (Dmitry Kalinkin, 8 weeks ago)
   add test for Date header with CFWS comment

8a895f1 (Fraser Tweedale, 8 weeks ago)
   RFC5322: redefine headerDate using new parser

   Fixes: https://github.com/purebred-mua/purebred-email/issues/49

8e0f105 (Fraser Tweedale, 8 weeks ago)
   RFC5322: add better date-time parsing

   Add better parser, following strictly the specification from RFC 5322
   section 3.3 "Date and Time Specification"[1]

   [1]: https://tools.ietf.org/html/rfc5322#section-3.3

   Part of: https://github.com/purebred-mua/purebred-email/issues/49

6352ddc (Fraser Tweedale, 8 weeks ago)
   RFC5322: export fws parser

020aade (Dmitry Kalinkin, 8 weeks ago)
   fix typo in the RFC number: should be 5322, not 5422

   find . -type f -exec sed -i 's/5422/5322/g' {} \;
```