### PR TITLE
implement boundary restrictions, other enhancements

### DIFF
--- a/purebred-email.cabal
+++ b/purebred-email.cabal
@@ -77,14 +77,15 @@ library
     , Data.MIME.Base64
     , Data.MIME.QuotedPrintable
   other-modules:
-    Data.MIME.Internal
+    Data.MIME.Boundary
+    , Data.MIME.Internal
     , Data.IMF.DateTime
-  -- other-extensions:    
   build-depends:
     , base64-bytestring >= 1 && < 2
     , case-insensitive >= 1.2 && < 1.3
     , concise >= 0.1.0.1 && < 1
     , deepseq >= 1.4.2
+    , random >= 1.2.0
     , semigroupoids >= 5 && < 6
     , stringsearch >= 0.3
   hs-source-dirs:      src
@@ -105,6 +106,7 @@ test-suite tests
     , Message
   build-depends:
     , purebred-email
+    , random
     , tasty
     , tasty-hedgehog
     , tasty-quickcheck

--- a/src/Data/IMF.hs
+++ b/src/Data/IMF.hs
@@ -24,7 +24,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 {- |
@@ -802,15 +801,15 @@ class RenderMessage a where
 
   -- | Allows tweaking the headers before rendering.  Default
   -- implementation is a no-op.
-  tweakHeaders :: Headers -> Headers
-  tweakHeaders = id
+  tweakHeaders :: a -> Headers -> Headers
+  tweakHeaders _ = id
 
 -- | Construct a 'Builder.Builder' for the message.  This allows efficient
 -- streaming to IO handles.
 --
 buildMessage :: forall ctx a. (RenderMessage a) => Message ctx a -> Builder.Builder
 buildMessage (Message h b) =
-  buildFields (tweakHeaders @a h)
+  buildFields (tweakHeaders b h)
   <> maybe mempty ("\r\n" <>) (buildBody h b)
 
 -- | Render a message to a lazy 'L.ByteString'.  (You will probably not

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -828,7 +828,7 @@ multipart takeTillEnd boundary =
 -- | Sets the @MIME-Version: 1.0@ header.
 --
 instance RenderMessage MIME where
-  tweakHeaders = set (headers . at "MIME-Version") (Just "1.0")
+  tweakHeaders _ = set (headers . at "MIME-Version") (Just "1.0")
   buildBody _h z = Just $ case z of
     Part partbody -> Builder.byteString partbody
     Encapsulated msg -> buildMessage msg

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -77,7 +77,6 @@ module Data.MIME
   , ctType
   , ctSubtype
   , matchContentType
-  , ctEq
   , parseContentType
   , renderContentType
   , showContentType
@@ -548,12 +547,6 @@ renderContentType (ContentType typ sub params) =
 printParameters :: Parameters -> B.ByteString
 printParameters (Parameters xs) =
   foldMap (\(k,v) -> "; " <> CI.original k <> "=" <> v) xs
-
--- | Are the type and subtype the same? (parameters are ignored)
---
-ctEq :: ContentType -> ContentType -> Bool
-ctEq (ContentType typ1 sub1 _) = matchContentType typ1 (Just sub1)
-{-# DEPRECATED ctEq "Use 'matchContentType' instead" #-}
 
 ctType :: Lens' ContentType (CI B.ByteString)
 ctType f (ContentType a b c) = fmap (\a' -> ContentType a' b c) (f a)

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -722,6 +722,13 @@ contentTypeMultipartMixed = contentTypeMultipart Mixed
 -- otherwise it is added.  Unrecognised Content-Transfer-Encoding
 -- is ignored when setting.
 --
+-- __Note__: when dealing with 'Multipart' or 'Encapsulated'
+-- messages, the @Content-Type@ header will be overridden when
+-- serialising the message.  This avoids scenarios where the
+-- @Content-Type@ does not match the structure of the message.  In
+-- general, the @Content-Type@ header should be treated as "read
+-- only" for multipart or encapsulated message.
+--
 contentType :: HasHeaders a => Lens' a ContentType
 contentType = headers . lens sa sbt where
   sa s = case view cte s of

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -923,7 +923,7 @@ instance RenderMessage MIME where
     where
       setContentType = case b of
         Multipart sub boundary _  -> set contentType (contentTypeMultipart sub boundary)
-        -- FIXME message/rfc822 for Encapsulated?
+        Encapsulated _msg         -> set contentType "message/rfc822"
         _                         -> id
   buildBody _h z = Just $ case z of
     Part partbody -> Builder.byteString partbody

--- a/src/Data/MIME/Boundary.hs
+++ b/src/Data/MIME/Boundary.hs
@@ -40,6 +40,7 @@ import System.Random.Stateful
 -- @
 --
 newtype Boundary = Boundary B.ByteString
+  deriving (Eq, Show)
 
 unBoundary :: Boundary -> B.ByteString
 unBoundary (Boundary s) = s

--- a/src/Data/MIME/Boundary.hs
+++ b/src/Data/MIME/Boundary.hs
@@ -1,0 +1,78 @@
+-- This file is part of purebred-email
+-- Copyright (C) 2021  Fraser Tweedale
+--
+-- purebred-email is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+module Data.MIME.Boundary
+  (
+    Boundary
+  , unBoundary
+  , makeBoundary
+  ) where
+
+import Control.Monad (replicateM)
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Internal as B
+import Data.ByteString.Char8 as C8
+import System.Random.Stateful
+
+-- | MIME boundary.  Use 'makeBoundary' to construct, and 'unBoundary'
+-- to unwrap.
+--
+-- Use the 'Uniform' instance to generate a random @Boundary@ to use
+-- when constructing messages.  For example:
+--
+-- @
+-- 'getStdRandom' 'uniform' :: MonadIO m =>  m Boundary
+-- 'getStdRandom' 'uniform' ::              IO Boundary
+-- @
+--
+newtype Boundary = Boundary B.ByteString
+
+unBoundary :: Boundary -> B.ByteString
+unBoundary (Boundary s) = s
+
+-- Boundary smart constructor that checks validity
+makeBoundary :: B.ByteString -> Either B.ByteString Boundary
+makeBoundary s
+  | B.null s                    = Left s
+  | B.length s > 70             = Left s
+  | B.any (not . validBchar) s  = Left s
+  | B.last s == 0x20            = Left s
+  | otherwise                   = Right $ Boundary s
+  where
+    validBchar c =
+      c >= 0x2c && c <= 0x3a -- ',', '-', '.', '/', '0'..'9', ':'
+      || c >= 0x41 && c <= 0x5a -- 'A'..'Z'
+      || c >= 0x61 && c <= 0x7a -- 'a'..'z'
+      || c >= 0x27 && c <= 0x29 -- '\'', '(', ')'
+      || c == 0x2b {- '+' -}
+      || c == 0x5f {- '_' -}
+      || c == 0x3d {- '=' -}
+      || c == 0x3f {- '?' -}
+      || c == 0x20 {- ' ' -}
+
+-- | Generate a random 'Boundary'
+genBoundary :: (StatefulGen g m) => g -> m Boundary
+genBoundary g = do
+  let
+    blen = 64
+    bchars = C8.pack $ ['0'..'9'] <> ['a'..'z'] <> ['A'..'Z'] <> "'()+_,-./:=?"
+  chars <-
+    replicateM blen $ B.index bchars <$> uniformRM (0, B.length bchars - 1) g
+  pure . Boundary $ B.unsafePackLenBytes blen chars
+
+instance Uniform Boundary where
+  uniformM = genBoundary

--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -92,7 +92,8 @@ multiPartMail =
                 "fileContentsASDF"
         nowUTC = UTCTime (ModifiedJulianDay 123) (secondsToDiffTime 123)
         now = utcToZonedTime utc nowUTC
-    in createMultipartMixedMessage "asdf" (fromList [p, a])
+        Right boundary = makeBoundary "asdf"
+    in createMultipartMixedMessage boundary (fromList [p, a])
        & set (headers . at "From") (Just $ renderMailboxes [from'])
        . set (headers . at "To") (Just $ renderAddresses [to'])
        . set (headers . at "Date") (Just $ renderRFC5322Date now)

--- a/tests/MIME.hs
+++ b/tests/MIME.hs
@@ -136,14 +136,14 @@ testContentDisposition =
         set
           (attachments . headers . contentDisposition . traversed . filenameParameter)
           Nothing
-        (Message (Headers []) (Multipart . fromList $
+        (Message (Headers []) (Multipart boundary . fromList $
           [ Message (Headers [("Content-Disposition", "inline; filename=msg.txt")]) (Part "")
           , Message (Headers [("Content-Disposition", "attachment; filename=foo.pdf")]) (Part "")
           , Message (Headers [("Content-Disposition", "attachment; filename=bar.pdf")]) (Part "")
           ]
         ))
         @?=
-        Message (Headers []) (Multipart . fromList $
+        Message (Headers []) (Multipart boundary . fromList $
           [ Message (Headers [("Content-Disposition", "inline; filename=msg.txt")]) (Part "")
           , Message (Headers [("Content-Disposition", "attachment")]) (Part "")
           , Message (Headers [("Content-Disposition", "attachment")]) (Part "")
@@ -153,6 +153,7 @@ testContentDisposition =
   where
     lFilename = headers . contentDisposition . traversed . filename defaultCharsets
     stripPath = snd . T.breakOnEnd "/"
+    Right boundary = makeBoundary "boundary"
 
 testParse :: TestTree
 testParse = testGroup "parsing tests"

--- a/tests/MIME.hs
+++ b/tests/MIME.hs
@@ -136,14 +136,14 @@ testContentDisposition =
         set
           (attachments . headers . contentDisposition . traversed . filenameParameter)
           Nothing
-        (Message (Headers []) (Multipart boundary . fromList $
+        (Message (Headers []) (Multipart Mixed boundary . fromList $
           [ Message (Headers [("Content-Disposition", "inline; filename=msg.txt")]) (Part "")
           , Message (Headers [("Content-Disposition", "attachment; filename=foo.pdf")]) (Part "")
           , Message (Headers [("Content-Disposition", "attachment; filename=bar.pdf")]) (Part "")
           ]
         ))
         @?=
-        Message (Headers []) (Multipart boundary . fromList $
+        Message (Headers []) (Multipart Mixed boundary . fromList $
           [ Message (Headers [("Content-Disposition", "inline; filename=msg.txt")]) (Part "")
           , Message (Headers [("Content-Disposition", "attachment")]) (Part "")
           , Message (Headers [("Content-Disposition", "attachment")]) (Part "")

--- a/tests/Message.hs
+++ b/tests/Message.hs
@@ -33,11 +33,13 @@ import Control.Lens (set, view)
 import qualified Data.ByteString as B
 import Data.CaseInsensitive
 import qualified Data.Text as T
+import System.Random (uniform)
 
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Hedgehog
 import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Internal.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Data.MIME
@@ -73,7 +75,7 @@ genMultipart = depths >>= go
   -- Generate a 50 character multipart boundary.  These MUST be unique
   -- for all (nested) multipart messages.  Assume negligible probability
   -- of collision.
-  genBoundary = Gen.utf8 (Range.singleton 50) printableAsciiChar
+  genBoundary = Gen.generate (\_size seed -> fst (uniform seed))
 
   go 0 = genTextPlain
   go n = createMultipartMixedMessage


### PR DESCRIPTION
This is quite a meaty pull request but the main things are:

- implement restrictions on boundary parameter as required by RFC

- implement random generator for boundary parameter

- remove deprecated `ctEq` function

- make content-type part of the structural representation of multipart and
  encapsulated messages.  This avoids accidental manipulation of the
  content-type that causes the header to no longer match the data structure.
  This is not yet bullet-proof - you can still manipulate the header, but the
  modified value will be ignored when serialising multipart or encapsulated
  messages.  It is a step in a good direction.

```
c7a0607 (Fraser Tweedale, 14 minutes ago)
   remove deprecated function ctEq

   ctEq has been deprecated since v0.1.0.0, the first public release of 
   purebred-email.  Time to remove it.

f1daab1 (Fraser Tweedale, 26 hours ago)
   add note about Content-Type inconsistency

b0aaefa (Fraser Tweedale, 26 hours ago)
   force message/rfc822 for Encapsulated messages

a787d91 (Fraser Tweedale, 27 hours ago)
   lift subtype field into Multipart constructor

   Multipart media subtypes have various semantics and differing required
   parameters.  Add constructors for known multipart media types, with
   arguments to represent their required and optional parameters.  This has
   the additional benefit of ensuring that discrepancies between the
   Content-Type header and the structural representation of the message,
   should any arise during library manipulation, can be disregarded (favouring
   the structural representation).

da9d025 (Fraser Tweedale, 35 hours ago)
   add function for general multipart Content-Type creation

ecbf620 (Fraser Tweedale, 35 hours ago)
   always set Content-Type header for Multipart body

   To ensure consistency, when rendering Multipart messages always ensure the
   Content-Type header is set to a "multipart/" type with the correct boundary
   parameter.

   If the existing headers has a multipart Content-Type, just (re)set the
   "boundary" parameter.  Otherwise, (re)set the Content-Type header to
   multipart/mixed with the correct boundary.

f5cced7 (Fraser Tweedale, 2 days ago)
   RenderMessage: pass body to tweakHeaders

   Sometimes it may be necessary to tweak the headers based on some property
   of the body value.  Update `tweakHeaders` with a body argument.

14ca9b4 (Fraser Tweedale, 2 days ago)
   lift Boundary into Multipart constructor

   To avoid situations where the `Content-Type` header is missing or does not
   have a valid boundary parameter, add a `Boundary` argument to the
   `Multipart` constructor.

6767685 (Fraser Tweedale, 2 days ago)
   implement restrictions on boundary values

   Implement RFC 2046 restrictions on multipart boundary parameter values. 
   This is accomplished via a `Boundary` newtype with smart constructor (and
   non-exported constructor).  Also instance `Uniform`
   (from package *random* >= 1.2.0) to provide a convenient way to generate
   conformant values.

   Fixes: https://github.com/purebred-mua/purebred-email/issues/33
```