### PR TITLE
fix: parsing of (text encoded) addresses

### DIFF
--- a/src/Data/IMF.hs
+++ b/src/Data/IMF.hs
@@ -150,6 +150,7 @@ module Data.IMF
   , Address(..)
   , address
   , addressList
+  , addressSpec
   , AddrSpec(..)
   , Domain(..)
   , Mailbox(..)

--- a/src/Data/IMF/Syntax.hs
+++ b/src/Data/IMF/Syntax.hs
@@ -43,6 +43,7 @@ module Data.IMF.Syntax
   , crlf
   , vchar
   , word
+  , dquote
   , quotedString
   , dotAtomText
   , dotAtom


### PR DESCRIPTION
This addresses the parsing issue of email addresses (specifically the display names) when using text parser. It mainly allows all non-ASCII letters, but sticks with the character classes of `atext`.

Fixes: #87 

This adds an additional exported symbol `addressSpec` as it is used to fix https://github.com/purebred-mua/purebred/issues/515