### PR TITLE
fix: parsing of (text encoded) addresses (now with more fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## Next
 
-- Support UTF-8 in `Subject` and other unstructured headers.
-  ([#82])
+- Support non-ASCII UTF-8 in `Subject` and other unstructured
+  headers.  ([#82])
+
+- Support non-ASCII UTF-8 in display name in the `Data.IMF.Text`
+  parser (the `ByteString` parser still only supports non-ASCII
+  input via encoded-word).  ([#87])
 
 [#82]: https://github.com/purebred-mua/purebred-email/issues/82
+[#87]: https://github.com/purebred-mua/purebred-email/issues/87
 
 
 ## Version 0.6 (2022-09-13)

--- a/src/Data/IMF.hs
+++ b/src/Data/IMF.hs
@@ -150,6 +150,7 @@ module Data.IMF
   , Address(..)
   , address
   , addressList
+  , addressSpec
   , AddrSpec(..)
   , Domain(..)
   , Mailbox(..)

--- a/src/Data/IMF/Syntax.hs
+++ b/src/Data/IMF/Syntax.hs
@@ -43,6 +43,7 @@ module Data.IMF.Syntax
   , crlf
   , vchar
   , word
+  , dquote
   , quotedString
   , dotAtomText
   , dotAtom


### PR DESCRIPTION
There were some deficiencies in #88 - in particular, quoted-string parsing did not accept non-ASCII chars.  This is an updated versions of #88 that fixes quoted string parsing too, and adds some additional test cases.

Fixes: https://github.com/purebred-mua/purebred-email/issues/87