### PR TITLE
support MIME subparts without bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@
 - Add `headerAuthor`, for and reading the `Author:` header field
   defined in [RFC 9057]. ([#77])
 
+- Add support for parsing MIME subparts without bodies.  The new
+  `entities'` traversal visits all parts, projecting `Just body`
+  where there is a body otherwise `Nothing`.  The `MIME` data type
+  gets the new `PartNoBody` constructor.  ([#90])
+
 [#77]: https://github.com/purebred-mua/purebred-email/issues/77
 [#81]: https://github.com/purebred-mua/purebred-email/issues/81
 [#82]: https://github.com/purebred-mua/purebred-email/issues/82
 [#87]: https://github.com/purebred-mua/purebred-email/issues/87
+[#90]: https://github.com/purebred-mua/purebred-email/issues/90
 
 
 ## Version 0.6 (2022-09-13)

--- a/test-vectors/multipart-no-body.eml
+++ b/test-vectors/multipart-no-body.eml
@@ -1,0 +1,18 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="------------VGV4VA5ahWZIEkhxyIbpi2vp"
+To: test@example.com
+From: test@example.com
+Subject: Test
+
+This is a multi-part message in MIME format.
+--------------VGV4VA5ahWZIEkhxyIbpi2vp
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+--------------VGV4VA5ahWZIEkhxyIbpi2vp
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+Hello World
+
+--------------VGV4VA5ahWZIEkhxyIbpi2vp--


### PR DESCRIPTION
Add support for parsing and constructing MIME parts without bodies. The new `entities'` traversal visits all parts, projecting `Just body` where there is a body, and `Nothing` where there is no body. The `MIME` data type gets the new `PartNoBody` constructor.

This was a rather intrusive change.  Instead of passing around the parser for "take a part at the current level", we pass around a new data type that represents the current level:

    data MIMELevel = Top | Nest B.ByteString {- delimiter -}

We construct the "take part" parser on-demand where needed, and when we are parsing terminal parts in a multipart message we avoid preceding the delimiter with CRLF.  This lets us detect and handle the "no body" case.

Fixes: https://github.com/purebred-mua/purebred-email/issues/90