### PR TITLE
Fix parsing of encoded words after folding whitespace.

### DIFF
--- a/src/Data/IMF.hs
+++ b/src/Data/IMF.hs
@@ -413,7 +413,7 @@ phrase charsets = foldMany1Sep " " $
   -- decode them, and concatenate the result.
   fmap
     ( foldMap (decodeEncodedWord charsets) )
-    ( ("=?" *> encodedWord) `sepBy1` char8 ' ' )
+    ( optionalCFWS *> ("=?" *> encodedWord) `sepBy1` char8 ' ' )
   <|> fmap decodeLenient word
 
 displayName :: CharsetLookup -> Parser T.Text


### PR DESCRIPTION
Consume whitespace before trying to parse an encoded word. Fixes the issue of encoded words not being recognized as such when there is folding whitespace before them.

Fixes https://github.com/purebred-mua/purebred-email/issues/93

However, I'm not exactly sure if `optionalCFWS` is the correct parser to do that.