### PR TITLE
Ignore whitespace between two successive EncodedWords

### DIFF
--- a/src/Data/MIME/EncodedWord.hs
+++ b/src/Data/MIME/EncodedWord.hs
@@ -35,7 +35,7 @@ module Data.MIME.EncodedWord
   ) where
 
 import Control.Applicative ((<|>), optional)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Monoid (Sum(Sum), Any(Any))
 
 import Control.Lens (to, clonePrism, review, view, foldMapOf)
@@ -46,6 +46,7 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.CaseInsensitive as CI
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
@@ -192,10 +193,14 @@ decodeEncodedWord charsets w =
 encodeEncodedWords :: T.Text -> B.ByteString
 encodeEncodedWords t = maybe utf8 (const ew) (chooseEncodedWordEncoding utf8)
   where
-    ew = B.intercalate " " . fmap encOrNot . B.split 32 $ utf8
-    encOrNot s = maybe s (g s) (chooseEncodedWordEncoding s)
-    g s (enc, p) = serialiseEncodedWord $
+    ew = B.intercalate " " $ fmap encOrNot $ concat $ fmap addSpaces $ groupedWords
+    encOrNot (Nothing, s) = s
+    encOrNot (Just (enc, p), s) = serialiseEncodedWord $
       EncodedWord "utf-8" Nothing enc (review (clonePrism p) s)
+    addSpaces x = NonEmpty.head x : fmap (fmap (" " <>)) (NonEmpty.tail x)
+    groupedWords = NonEmpty.groupBy (\x y -> isJust (fst x) && isJust (fst y)) wordsWithEnc
+    wordsWithEnc = fmap addEncoding $ B.split 32 $ utf8
+    addEncoding s = (chooseEncodedWordEncoding s, s)
     utf8 = T.encodeUtf8 t
 
 chooseEncodedWordEncoding :: B.ByteString -> Maybe (TransferEncodingName, TransferEncoding)

--- a/src/Data/MIME/EncodedWord.hs
+++ b/src/Data/MIME/EncodedWord.hs
@@ -54,7 +54,7 @@ import Data.MIME.Error (EncodingError)
 import Data.MIME.TransferEncoding
 import Data.MIME.Base64
 import Data.MIME.QuotedPrintable
-import Data.IMF.Syntax (ci, takeTillString)
+import Data.IMF.Syntax (ci, takeTillString, isWsp)
 
 {-# ANN module ("HLint: ignore Eta reduce" :: String) #-}
 
@@ -158,6 +158,13 @@ transferEncodeEncodedWord (TransferDecodedEncodedWord charset lang s) =
 -- hola mundo!
 -- @
 --
+-- Whitespace between two encoded words is ignored (see RFC 2047 6.2)
+--
+-- @
+-- λ> T.putStrLn $ decodeEncodedWords defaultCharsets "=?utf-8?B?55Sw?= =?utf-8?B?55Sw?="
+-- 田田
+-- @
+--
 decodeEncodedWords :: CharsetLookup -> B.ByteString -> T.Text
 decodeEncodedWords charsets s =
   either (const (decodeLenient s)) (foldMap conv) (parseOnly tokens s)
@@ -165,7 +172,9 @@ decodeEncodedWords charsets s =
     tokens :: Parser [Either B.ByteString EncodedWord]
     tokens = liftA2 (:) (Left <$> takeTillString "=?") more
           <|> ((:[]) . Left <$> takeByteString)
-    more = liftA2 (:) (Right <$> encodedWord <|> pure (Left "=?")) tokens
+    more = liftA2 (:) (Right <$> encodedWord) evenMore <|> liftA2 (:) (pure (Left "=?")) tokens
+    evenMore = liftA2 (:) (Right <$> (takeWhile1 isWsp *> string "=?" *> encodedWord)) evenMore
+          <|> tokens
     conv = either decodeLenient (decodeEncodedWord charsets)
 
 -- | Decode an 'EncodedWord'.  If transfer or charset decoding fails,


### PR DESCRIPTION
Quoting RFC 2047 6.2:
  When displaying a particular header field that contains multiple
  'encoded-word's, any 'linear-white-space' that separates a pair of
  adjacent 'encoded-word's is ignored.

Fixes: https://github.com/purebred-mua/purebred-email/issues/95