### PR TITLE
bytes fold on chooseTransferEncoding leaks memory

### DIFF
--- a/purebred-email.cabal
+++ b/purebred-email.cabal
@@ -84,6 +84,7 @@ common common
     , attoparsec >= 0.13 && < 0.15
     , bytestring >= 0.10 && < 0.13
     , case-insensitive >= 1.2 && < 1.3
+    , encoding >= 0.8.9 && < 1.0.0
     , lens >= 4 && < 6
     , text >= 1.2
     , time >= 1.9

--- a/src/Data/IMF.hs
+++ b/src/Data/IMF.hs
@@ -211,7 +211,7 @@ import Data.IMF.Syntax
   ( CI, ci, mk, original
   , (<<>>), foldMany, foldMany1Sep
   , char, fromChar, isAtext, isQtext, isVchar, isWsp
-  , optionalCFWS, word, wsp, vchar, optionalFWS, crlf
+  , optionalCFWS, word, wsp, vcharUtf8, optionalFWS, crlf
   , domainLiteral, dotAtom, dotAtomText, localPart, quotedString
   )
 import {-# SOURCE #-} Data.IMF.Text (readMailbox)
@@ -899,9 +899,10 @@ field = (,)
   <*  char8 ':' <* many wsp
   <*> unstructured <* crlf
 
+-- | UTF-8 unstructured text
 unstructured :: Parser B.ByteString
 unstructured =
-  foldMany (optionalFWS <<>> (B.singleton <$> vchar))
+  foldMany (optionalFWS <<>> fmap B.pack vcharUtf8)
   <<>> A.takeWhile isWsp
 
 

--- a/src/Data/IMF.hs
+++ b/src/Data/IMF.hs
@@ -416,7 +416,7 @@ phrase charsets = foldMany1Sep " " $
   -- decode them, and concatenate the result.
   fmap
     ( foldMap (decodeEncodedWord charsets) )
-    ( ("=?" *> encodedWord) `sepBy1` char8 ' ' )
+    ( many1' ((optionalCFWS *> "=?" *> encodedWord) <* optionalCFWS) )
   <|> fmap decodeLenient word
 
 displayName :: CharsetLookup -> Parser T.Text

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -48,6 +48,7 @@ module Data.MIME
   -- ** MIME data type
     MIME(..)
   , mime
+  , mime'
   , MIMEMessage
 
   , WireEntity

--- a/src/Data/MIME.hs
+++ b/src/Data/MIME.hs
@@ -734,7 +734,8 @@ textCharsetSources =
 
   -- https://tools.ietf.org/html/rfc2854
   -- The default is ambiguous; using us-ascii for now
-  , ("html", InPayloadOrParameter (\_param _payload -> Just "us-ascii")) -- FIXME
+  -- TODO: perhaps analyze html content to determine charset
+  , ("html", InPayloadOrParameter (\param _payload -> param <|> Just "us-ascii"))
 
   -- https://tools.ietf.org/html/rfc7763
   , ("markdown", InParameter Nothing)

--- a/src/Data/MIME/Charset.hs
+++ b/src/Data/MIME/Charset.hs
@@ -56,6 +56,15 @@ import qualified Data.CaseInsensitive as CI
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as T
+import Data.Encoding
+import Data.Encoding.CP1251
+import Data.Encoding.CP1252
+import Data.Encoding.CP1256
+import Data.Encoding.CP932
+import Data.Encoding.ISO2022JP
+import Data.Encoding.ISO885915
+import Data.Encoding.ISO88592
+import Data.Encoding.KOI8R
 
 {-# ANN module ("HLint: ignore Use camelCase" :: String) #-}
 
@@ -186,16 +195,19 @@ charsets =
   , ("csUTF32", utf32)
 
   -- Other charsets I observed in my mail corpus.
-  -- , ("iso-8859-2", ...)
-  -- , ("iso-8859-15", ...)
-  -- , ("iso-2022-jp", ...)    (common)
-  -- , ("windows-1252", ...)   (common)
-  -- , ("windows-1256", ...)
-  -- , ("cp1252", ...)         (alias of windows-1252)
+  , ("iso-8859-2", iso_8859_2)
+  , ("iso-8859-15", iso_8859_15)
+  , ("iso-2022-jp", iso_2022_jp)
+  , ("windows-1251", cp1251) -- (Russian)
+  , ("windows-1252", cp1252)
+  , ("windows-1256", cp1256)
+  , ("cp1251", cp1251)       -- (Russian)
+  , ("cp1252", cp1252)
   -- , ("big5", ...)           (common)
   -- , ("euc-kr", ...)
-  -- , ("cp932", ...)
+  , ("cp932", cp932)          -- (Japanese)
   -- , ("gb2312", ...)         (Chinese)
+  , ("koi8-r", koi8_r)        -- (Russian)
   ]
 
 us_ascii, utf_8, iso_8859_1 :: Charset
@@ -220,6 +232,29 @@ utf32 b = case B.take 4 b of
   "\xff\xfe\x00\x00"  -> utf32le b
   _                   -> utf32be b
 
+cp932 :: Charset
+cp932 = T.pack . decodeStrictByteString CP932
+
+cp1251 :: Charset
+cp1251 = T.pack . decodeStrictByteString CP1251
+
+cp1252 :: Charset
+cp1252 = T.pack . decodeStrictByteString CP1252
+
+cp1256 :: Charset
+cp1256 = T.pack . decodeStrictByteString CP1256
+
+iso_2022_jp :: Charset
+iso_2022_jp = T.pack . decodeStrictByteString ISO2022JP
+
+iso_8859_2 :: Charset
+iso_8859_2 = T.pack . decodeStrictByteString ISO88592
+
+iso_8859_15 :: Charset
+iso_8859_15 = T.pack . decodeStrictByteString ISO885915
+
+koi8_r :: Charset
+koi8_r = T.pack . decodeStrictByteString KOI8R
 
 type CharsetLookup = CI.CI B.ByteString -> Maybe Charset
 


### PR DESCRIPTION
Hello, I traced back a leak on chatfusion to a function on purebreed. The culprit is the following function
```
chooseTransferEncoding :: B.ByteString -> (TransferEncodingName, TransferEncoding)
chooseTransferEncoding s
  -- TODO: does not handle max line length of 998
  | not doEnc = ("7bit", id)
  | nQP < nB64 = ("quoted-printable", contentTransferEncodingQuotedPrintable)
  | otherwise = ("base64", contentTransferEncodingBase64)
  where
    -- https://tools.ietf.org/html/rfc5322#section-3.5 'text'
    needEnc c = c > 127 || c == 0
    qpBytes c
      | encodingRequiredNonEOL QuotedPrintable c = 3
      | otherwise = 1
    (Any doEnc, Sum nQP) = foldMapOf bytes (\c -> (Any (needEnc c), Sum (qpBytes c))) s
    nB64 = ((B.length s + 2) `div` 3) * 4
```
The foldMapOf call is too lazy. The tuple does not get reduced. I replaced the offending lines for two separated folds like this 
```
    doEnc = isNothing $ B.find needEnc s
    nQP = B.foldl' (\acc a -> acc + qpBytes a) 0 s
```

## Corroborating the fix works

Originally a used the `createAttachment` function that calls this function over a 20 mebibytes attachments and got this figures

<img width="1155" height="831" alt="image" src="https://github.com/user-attachments/assets/6b7c58c7-5c7b-4e68-8a2f-e9506b340d4f" />

After the fix it looks like this

<img width="1155" height="831" alt="image" src="https://github.com/user-attachments/assets/4dcb23e5-1a45-4962-b8d9-78f909091cba" />

Sure, it is still linear in regards the input (copying GC, haskell data types overhead). But at least it is an improvement. 

I attach the eventlogs
[leak-fix.eventlog.html](https://github.com/user-attachments/files/24661537/leak-fix.eventlog.html)
[leak.eventlog.html](https://github.com/user-attachments/files/24661539/leak.eventlog.html)

